### PR TITLE
Add WebSocket server and client support for v2

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
+	github.com/gorilla/websocket v1.4.2
 	github.com/huaweicloud/huaweicloud-sdk-go-obs v3.25.9+incompatible
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/labstack/echo/v5 v5.0.4
@@ -104,7 +105,6 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.11 // indirect
 	github.com/googleapis/gax-go/v2 v2.17.0 // indirect
-	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.6.0 // indirect

--- a/v2/httpw/echow/ws.go
+++ b/v2/httpw/echow/ws.go
@@ -1,0 +1,24 @@
+package echow
+
+import (
+	"github.com/AndreeJait/go-utility/v2/websocketw"
+	"github.com/labstack/echo/v5"
+)
+
+// WSUpgradeHandler returns an Echo handler that upgrades HTTP connections
+// to WebSocket using the provided websocketw.Server.
+//
+// The server handles authentication internally if configured via gorillaw.Config.Authenticator.
+// If the Echo router already has AuthMiddleware applied, the server will detect the
+// existing auth result in context and skip redundant authentication.
+//
+// Usage:
+//
+//	ws := gorillaw.New(&gorillaw.Config{Authenticator: auth})
+//	e.GET("/ws", echow.WSUpgradeHandler(ws))
+func WSUpgradeHandler(srv websocketw.Server) echo.HandlerFunc {
+	return func(c *echo.Context) error {
+		srv.ServeHTTP(c.Response(), c.Request())
+		return nil
+	}
+}

--- a/v2/httpw/echow/ws_test.go
+++ b/v2/httpw/echow/ws_test.go
@@ -1,0 +1,88 @@
+package echow
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AndreeJait/go-utility/v2/websocketw"
+	"github.com/AndreeJait/go-utility/v2/websocketw/gorillaw"
+	"github.com/gorilla/websocket"
+)
+
+func TestEcho_WSUpgradeHandler(t *testing.T) {
+	ws := gorillaw.New(nil)
+	ws.OnEvent("echo.test", func(ctx context.Context, msg *websocketw.Message) error {
+		// Echo the message back
+		return ws.Send(ctx, "test-client", &websocketw.Message{Event: "echo.reply", Payload: msg.Payload})
+	})
+
+	e := setupEcho()
+	e.GET("/ws", WSUpgradeHandler(ws))
+
+	ts := httptest.NewServer(e)
+	defer ts.Close()
+	defer ws.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL+"/ws", nil)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+}
+
+func TestEcho_WSBroadcast(t *testing.T) {
+	ws := gorillaw.New(nil)
+
+	e := setupEcho()
+	e.GET("/ws", WSUpgradeHandler(ws))
+
+	ts := httptest.NewServer(e)
+	defer ts.Close()
+	defer ws.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	conn1, _, _ := websocket.DefaultDialer.Dial(wsURL+"/ws", nil)
+	defer conn1.Close()
+
+	conn2, _, _ := websocket.DefaultDialer.Dial(wsURL+"/ws", nil)
+	defer conn2.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	ctx := context.Background()
+	msg := &websocketw.Message{Event: "broadcast", Payload: []byte("hello from echo")}
+	ws.Broadcast(ctx, msg)
+
+	time.Sleep(50 * time.Millisecond)
+
+	conn1.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg1, err := conn1.ReadMessage()
+	if err != nil {
+		t.Errorf("client1 failed to read broadcast: %v", err)
+	}
+
+	conn2.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg2, err := conn2.ReadMessage()
+	if err != nil {
+		t.Errorf("client2 failed to read broadcast: %v", err)
+	}
+
+	if len(msg1) == 0 || len(msg2) == 0 {
+		t.Error("expected both clients to receive broadcast")
+	}
+
+	// Verify the message content
+	var parsed websocketw.Message
+	if err := json.Unmarshal(msg1, &parsed); err != nil {
+		t.Errorf("failed to unmarshal message: %v", err)
+	}
+	if parsed.Event != "broadcast" {
+		t.Errorf("expected event 'broadcast', got '%s'", parsed.Event)
+	}
+}

--- a/v2/httpw/ginw/ws.go
+++ b/v2/httpw/ginw/ws.go
@@ -1,0 +1,23 @@
+package ginw
+
+import (
+	"github.com/AndreeJait/go-utility/v2/websocketw"
+	"github.com/gin-gonic/gin"
+)
+
+// WSUpgradeHandler returns a Gin handler that upgrades HTTP connections
+// to WebSocket using the provided websocketw.Server.
+//
+// The server handles authentication internally if configured via gorillaw.Config.Authenticator.
+// If the Gin router already has AuthMiddleware applied, the server will detect the
+// existing auth result in context and skip redundant authentication.
+//
+// Usage:
+//
+//	ws := gorillaw.New(&gorillaw.Config{Authenticator: auth})
+//	r.GET("/ws", ginw.WSUpgradeHandler(ws))
+func WSUpgradeHandler(srv websocketw.Server) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		srv.ServeHTTP(c.Writer, c.Request)
+	}
+}

--- a/v2/httpw/ginw/ws_test.go
+++ b/v2/httpw/ginw/ws_test.go
@@ -1,0 +1,84 @@
+package ginw
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AndreeJait/go-utility/v2/websocketw"
+	"github.com/AndreeJait/go-utility/v2/websocketw/gorillaw"
+	"github.com/gorilla/websocket"
+)
+
+func TestGin_WSUpgradeHandler(t *testing.T) {
+	ws := gorillaw.New(nil)
+
+	r := setupGin()
+	r.GET("/ws", WSUpgradeHandler(ws))
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+	defer ws.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL+"/ws", nil)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+}
+
+func TestGin_WSBroadcast(t *testing.T) {
+	ws := gorillaw.New(nil)
+
+	r := setupGin()
+	r.GET("/ws", WSUpgradeHandler(ws))
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+	defer ws.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	conn1, _, _ := websocket.DefaultDialer.Dial(wsURL+"/ws", nil)
+	defer conn1.Close()
+
+	conn2, _, _ := websocket.DefaultDialer.Dial(wsURL+"/ws", nil)
+	defer conn2.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	ctx := context.Background()
+	msg := &websocketw.Message{Event: "broadcast", Payload: []byte("hello from gin")}
+	ws.Broadcast(ctx, msg)
+
+	time.Sleep(50 * time.Millisecond)
+
+	conn1.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg1, err := conn1.ReadMessage()
+	if err != nil {
+		t.Errorf("client1 failed to read broadcast: %v", err)
+	}
+
+	conn2.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg2, err := conn2.ReadMessage()
+	if err != nil {
+		t.Errorf("client2 failed to read broadcast: %v", err)
+	}
+
+	if len(msg1) == 0 || len(msg2) == 0 {
+		t.Error("expected both clients to receive broadcast")
+	}
+
+	// Verify the message content
+	var parsed websocketw.Message
+	if err := json.Unmarshal(msg1, &parsed); err != nil {
+		t.Errorf("failed to unmarshal message: %v", err)
+	}
+	if parsed.Event != "broadcast" {
+		t.Errorf("expected event 'broadcast', got '%s'", parsed.Event)
+	}
+}

--- a/v2/httpw/muxw/ws.go
+++ b/v2/httpw/muxw/ws.go
@@ -1,0 +1,29 @@
+package muxw
+
+import (
+	"net/http"
+
+	"github.com/AndreeJait/go-utility/v2/websocketw"
+)
+
+// WSUpgradeHandler returns an http.HandlerFunc that upgrades HTTP connections
+// to WebSocket using the provided websocketw.Server.
+//
+// Since websocketw.Server already implements http.Handler via ServeHTTP,
+// you can also mount it directly without this adapter:
+//
+//	r.Handle("/ws", ws)
+//
+// The server handles authentication internally if configured via gorillaw.Config.Authenticator.
+// If the Mux router already has AuthMiddleware applied, the server will detect the
+// existing auth result in context and skip redundant authentication.
+//
+// Usage with adapter:
+//
+//	ws := gorillaw.New(&gorillaw.Config{Authenticator: auth})
+//	r.HandleFunc("/ws", muxw.WSUpgradeHandler(ws))
+func WSUpgradeHandler(srv websocketw.Server) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		srv.ServeHTTP(w, r)
+	}
+}

--- a/v2/httpw/muxw/ws_test.go
+++ b/v2/httpw/muxw/ws_test.go
@@ -1,0 +1,84 @@
+package muxw
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AndreeJait/go-utility/v2/websocketw"
+	"github.com/AndreeJait/go-utility/v2/websocketw/gorillaw"
+	"github.com/gorilla/websocket"
+)
+
+func TestMux_WSUpgradeHandler(t *testing.T) {
+	ws := gorillaw.New(nil)
+
+	r := New(&Config{DebugMode: true})
+	r.HandleFunc("/ws", WSUpgradeHandler(ws))
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+	defer ws.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL+"/ws", nil)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+}
+
+func TestMux_WSBroadcast(t *testing.T) {
+	ws := gorillaw.New(nil)
+
+	r := New(&Config{DebugMode: true})
+	r.HandleFunc("/ws", WSUpgradeHandler(ws))
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+	defer ws.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	conn1, _, _ := websocket.DefaultDialer.Dial(wsURL+"/ws", nil)
+	defer conn1.Close()
+
+	conn2, _, _ := websocket.DefaultDialer.Dial(wsURL+"/ws", nil)
+	defer conn2.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	ctx := context.Background()
+	msg := &websocketw.Message{Event: "broadcast", Payload: []byte("hello from mux")}
+	ws.Broadcast(ctx, msg)
+
+	time.Sleep(50 * time.Millisecond)
+
+	conn1.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg1, err := conn1.ReadMessage()
+	if err != nil {
+		t.Errorf("client1 failed to read broadcast: %v", err)
+	}
+
+	conn2.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg2, err := conn2.ReadMessage()
+	if err != nil {
+		t.Errorf("client2 failed to read broadcast: %v", err)
+	}
+
+	if len(msg1) == 0 || len(msg2) == 0 {
+		t.Error("expected both clients to receive broadcast")
+	}
+
+	// Verify the message content
+	var parsed websocketw.Message
+	if err := json.Unmarshal(msg1, &parsed); err != nil {
+		t.Errorf("failed to unmarshal message: %v", err)
+	}
+	if parsed.Event != "broadcast" {
+		t.Errorf("expected event 'broadcast', got '%s'", parsed.Event)
+	}
+}

--- a/v2/websocketw/gorillaw/client.go
+++ b/v2/websocketw/gorillaw/client.go
@@ -1,0 +1,286 @@
+package gorillaw
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/AndreeJait/go-utility/v2/logw"
+	"github.com/AndreeJait/go-utility/v2/websocketw"
+	"github.com/gorilla/websocket"
+)
+
+// Compile-time interface compliance check.
+var _ websocketw.Client = (*wsClient)(nil)
+
+// ClientConfig holds the configuration options for the WebSocket client.
+type ClientConfig struct {
+	// URL is the WebSocket server URL to connect to (e.g., "ws://localhost:8080/ws").
+	URL string
+
+	// Header is optional HTTP headers sent during the handshake (e.g., for auth tokens).
+	Header http.Header
+
+	// AutoReconnect enables automatic reconnection when the connection drops.
+	// Default: false.
+	AutoReconnect bool
+
+	// ReconnectInterval is the delay between reconnection attempts.
+	// Default: 3 seconds.
+	ReconnectInterval time.Duration
+
+	// MaxReconnectAttempts limits reconnection tries. 0 = unlimited.
+	MaxReconnectAttempts int
+
+	// DebugMode enables verbose logging of client operations.
+	DebugMode bool
+}
+
+type wsClient struct {
+	cfg          *ClientConfig
+	conn         *websocket.Conn
+	connMu       sync.Mutex
+	eventMap     map[websocketw.EventType][]websocketw.Handler
+	onConnect    websocketw.ClientConnectHandler
+	onDisconnect websocketw.ClientDisconnectHandler
+	mu           sync.RWMutex
+	done         chan struct{}
+}
+
+// NewClient creates a new gorilla/websocket-based WebSocket client.
+func NewClient(cfg *ClientConfig) websocketw.Client {
+	if cfg == nil {
+		cfg = &ClientConfig{}
+	}
+	if cfg.ReconnectInterval == 0 {
+		cfg.ReconnectInterval = 3 * time.Second
+	}
+	return &wsClient{
+		cfg:      cfg,
+		eventMap: make(map[websocketw.EventType][]websocketw.Handler),
+		done:     make(chan struct{}),
+	}
+}
+
+// Connect establishes a WebSocket connection and starts listening for messages.
+// It blocks until the context is canceled or a fatal error occurs.
+func (c *wsClient) Connect(ctx context.Context) error {
+	return c.connectLoop(ctx)
+}
+
+func (c *wsClient) connectLoop(ctx context.Context) error {
+	attempts := 0
+
+	for {
+		select {
+		case <-c.done:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		conn, err := c.dial(ctx)
+		if err != nil {
+			logw.CtxErrorf(ctx, "[WS-CLIENT] dial failed: %v", err)
+
+			if !c.cfg.AutoReconnect {
+				return fmt.Errorf("gorillaw: connect failed: %w", err)
+			}
+
+			attempts++
+			if c.cfg.MaxReconnectAttempts > 0 && attempts > c.cfg.MaxReconnectAttempts {
+				return fmt.Errorf("gorillaw: max reconnect attempts (%d) reached", c.cfg.MaxReconnectAttempts)
+			}
+
+			logw.CtxInfof(ctx, "[WS-CLIENT] reconnecting in %v (attempt %d)...", c.cfg.ReconnectInterval, attempts)
+
+			select {
+			case <-time.After(c.cfg.ReconnectInterval):
+				continue
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-c.done:
+				return nil
+			}
+		}
+
+		// Reset attempt counter on successful connection
+		attempts = 0
+
+		// Invoke onConnect handler
+		if c.onConnect != nil {
+			if err := c.onConnect(ctx); err != nil {
+				logw.CtxErrorf(ctx, "[WS-CLIENT] onConnect handler failed: %v", err)
+			}
+		}
+
+		// Read messages until disconnection
+		readErr := c.readMessages(ctx, conn)
+
+		// Invoke onDisconnect handler
+		if c.onDisconnect != nil {
+			c.onDisconnect(ctx)
+		}
+
+		// If not auto-reconnect, return the error
+		if !c.cfg.AutoReconnect {
+			if readErr != nil {
+				return readErr
+			}
+			return nil
+		}
+
+		// Wait before reconnecting
+		logw.CtxInfof(ctx, "[WS-CLIENT] disconnected, reconnecting in %v...", c.cfg.ReconnectInterval)
+		select {
+		case <-time.After(c.cfg.ReconnectInterval):
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-c.done:
+			return nil
+		}
+	}
+}
+
+func (c *wsClient) dial(ctx context.Context) (*websocket.Conn, error) {
+	u, err := url.Parse(c.cfg.URL)
+	if err != nil {
+		return nil, fmt.Errorf("gorillaw: invalid URL: %w", err)
+	}
+
+	if u.Scheme == "https" {
+		u.Scheme = "wss"
+	} else if u.Scheme == "http" {
+		u.Scheme = "ws"
+	}
+
+	dialer := websocket.DefaultDialer
+	conn, _, err := dialer.DialContext(ctx, u.String(), c.cfg.Header)
+	if err != nil {
+		return nil, err
+	}
+
+	c.connMu.Lock()
+	c.conn = conn
+	c.connMu.Unlock()
+
+	logw.CtxInfof(ctx, "[WS-CLIENT] connected to %s", u.String())
+	return conn, nil
+}
+
+func (c *wsClient) readMessages(ctx context.Context, conn *websocket.Conn) error {
+	for {
+		select {
+		case <-c.done:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
+				logw.CtxErrorf(ctx, "[WS-CLIENT] unexpected close: %v", err)
+				return err
+			}
+			logw.CtxInfof(ctx, "[WS-CLIENT] connection closed: %v", err)
+			return nil
+		}
+
+		if c.cfg.DebugMode {
+			logw.CtxInfof(ctx, "[WS-CLIENT] received message: %s", string(message))
+		}
+
+		var msg websocketw.Message
+		if err := json.Unmarshal(message, &msg); err != nil {
+			logw.CtxErrorf(ctx, "[WS-CLIENT] failed to unmarshal message: %v", err)
+			continue
+		}
+
+		// Look up registered handlers for this event type
+		c.mu.RLock()
+		handlers, ok := c.eventMap[msg.Event]
+		c.mu.RUnlock()
+
+		if !ok || len(handlers) == 0 {
+			logw.CtxInfof(ctx, "[WS-CLIENT] no handler registered for event '%s'", msg.Event)
+			continue
+		}
+
+		// Execute the handler chain
+		if err := websocketw.ExecuteHandlers(ctx, &msg, handlers...); err != nil {
+			logw.CtxErrorf(ctx, "[WS-CLIENT] handler chain failed for event '%s': %v", msg.Event, err)
+		}
+	}
+}
+
+// Send publishes a message to the connected WebSocket server.
+func (c *wsClient) Send(ctx context.Context, msg *websocketw.Message) error {
+	c.connMu.Lock()
+	conn := c.conn
+	c.connMu.Unlock()
+
+	if conn == nil {
+		return fmt.Errorf("gorillaw: not connected")
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("gorillaw: failed to marshal message: %w", err)
+	}
+
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+
+	if err := c.conn.WriteMessage(websocket.TextMessage, data); err != nil {
+		return fmt.Errorf("gorillaw: write failed: %w", err)
+	}
+
+	if c.cfg.DebugMode {
+		logw.CtxInfof(ctx, "[WS-CLIENT] sent message: event=%s", msg.Event)
+	}
+
+	return nil
+}
+
+// OnEvent registers handlers for a specific event type received from the server.
+func (c *wsClient) OnEvent(event websocketw.EventType, handlers ...websocketw.Handler) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.eventMap[event] = append(c.eventMap[event], handlers...)
+}
+
+// OnConnect registers a handler invoked when the client successfully connects.
+func (c *wsClient) OnConnect(handler websocketw.ClientConnectHandler) {
+	c.onConnect = handler
+}
+
+// OnDisconnect registers a handler invoked when the client disconnects.
+func (c *wsClient) OnDisconnect(handler websocketw.ClientDisconnectHandler) {
+	c.onDisconnect = handler
+}
+
+// Close gracefully closes the WebSocket connection.
+func (c *wsClient) Close() error {
+	close(c.done)
+
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+
+	if c.conn != nil {
+		err := c.conn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, "client shutting down"))
+		c.conn.Close()
+		c.conn = nil
+		logw.Info("[WS-CLIENT] closed")
+		return err
+	}
+
+	return nil
+}

--- a/v2/websocketw/gorillaw/client_test.go
+++ b/v2/websocketw/gorillaw/client_test.go
@@ -1,0 +1,389 @@
+package gorillaw
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AndreeJait/go-utility/v2/websocketw"
+	"github.com/gorilla/websocket"
+)
+
+func TestClient_NewClient(t *testing.T) {
+	c := NewClient(&ClientConfig{URL: "ws://localhost:8080/ws"})
+	if c == nil {
+		t.Fatal("expected non-nil client")
+	}
+}
+
+func TestClient_ConnectAndReceive(t *testing.T) {
+	// Set up a WebSocket server
+	srv := New(nil)
+	srv.OnEvent("client.hello", func(ctx context.Context, msg *websocketw.Message) error {
+		// Echo back with a different event
+		srv.Broadcast(ctx, &websocketw.Message{
+			Event:   "server.reply",
+			Payload: msg.Payload,
+		})
+		return nil
+	})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	// Set up the client
+	received := make(chan *websocketw.Message, 1)
+	client := NewClient(&ClientConfig{URL: wsURL})
+	client.OnEvent("server.reply", func(ctx context.Context, msg *websocketw.Message) error {
+		received <- msg
+		return nil
+	})
+
+	// Connect in background
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go client.Connect(ctx)
+
+	// Wait for client to connect
+	time.Sleep(200 * time.Millisecond)
+
+	// Send a message from the client through a raw connection to the server
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("failed to dial server: %v", err)
+	}
+	defer conn.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Server broadcasts to all clients, including our wsClient
+	msg := &websocketw.Message{Event: "server.reply", Payload: []byte("hello client")}
+	srv.Broadcast(ctx, msg)
+
+	select {
+	case got := <-received:
+		if got.Event != "server.reply" {
+			t.Errorf("expected event 'server.reply', got '%s'", got.Event)
+		}
+		if string(got.Payload) != "hello client" {
+			t.Errorf("expected payload 'hello client', got '%s'", string(got.Payload))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for client to receive message")
+	}
+
+	client.Close()
+}
+
+func TestClient_Send(t *testing.T) {
+	// Set up a WebSocket server that echoes messages back
+	var mu sync.Mutex
+	var lastMsg *websocketw.Message
+
+	srv := New(nil)
+	srv.OnEvent("client.send", func(ctx context.Context, msg *websocketw.Message) error {
+		mu.Lock()
+		lastMsg = msg
+		mu.Unlock()
+		return nil
+	})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	client := NewClient(&ClientConfig{URL: wsURL})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go client.Connect(ctx)
+
+	// Wait for client to connect
+	time.Sleep(200 * time.Millisecond)
+
+	// Send a message from the client
+	msg := &websocketw.Message{Event: "client.send", Payload: []byte("from client")}
+	if err := client.Send(ctx, msg); err != nil {
+		t.Fatalf("failed to send: %v", err)
+	}
+
+	// Wait for server to process
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	got := lastMsg
+	mu.Unlock()
+
+	if got == nil {
+		t.Fatal("expected server to receive message from client")
+	}
+	if got.Event != "client.send" {
+		t.Errorf("expected event 'client.send', got '%s'", got.Event)
+	}
+	if string(got.Payload) != "from client" {
+		t.Errorf("expected payload 'from client', got '%s'", string(got.Payload))
+	}
+
+	client.Close()
+}
+
+func TestClient_OnConnect(t *testing.T) {
+	connectCalled := make(chan struct{}, 1)
+
+	srv := New(nil)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	client := NewClient(&ClientConfig{URL: wsURL})
+	client.OnConnect(func(ctx context.Context) error {
+		connectCalled <- struct{}{}
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go client.Connect(ctx)
+
+	select {
+	case <-connectCalled:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for onConnect handler")
+	}
+
+	client.Close()
+}
+
+func TestClient_OnDisconnect(t *testing.T) {
+	disconnectCalled := make(chan struct{}, 1)
+
+	srv := New(nil)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	client := NewClient(&ClientConfig{URL: wsURL})
+	client.OnDisconnect(func(ctx context.Context) {
+		disconnectCalled <- struct{}{}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go client.Connect(ctx)
+	time.Sleep(200 * time.Millisecond)
+
+	// Close the server to force client disconnect
+	srv.Close()
+
+	select {
+	case <-disconnectCalled:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for onDisconnect handler")
+	}
+
+	client.Close()
+}
+
+func TestClient_Close(t *testing.T) {
+	srv := New(nil)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	client := NewClient(&ClientConfig{URL: wsURL})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go client.Connect(ctx)
+	time.Sleep(200 * time.Millisecond)
+
+	if err := client.Close(); err != nil {
+		t.Errorf("expected clean close, got error: %v", err)
+	}
+}
+
+func TestClient_SendWhenNotConnected(t *testing.T) {
+	client := NewClient(&ClientConfig{URL: "ws://localhost:99999/ws"})
+
+	ctx := context.Background()
+	msg := &websocketw.Message{Event: "test", Payload: []byte("data")}
+	err := client.Send(ctx, msg)
+	if err == nil {
+		t.Error("expected error when sending while not connected")
+	}
+}
+
+func TestClient_MiddlewareChain(t *testing.T) {
+	var order []string
+	var mu sync.Mutex
+	done := make(chan struct{}, 1)
+
+	srv := New(nil)
+	srv.OnEvent("chain.test", func(ctx context.Context, msg *websocketw.Message) error {
+		// Broadcast back to all clients
+		srv.Broadcast(ctx, &websocketw.Message{Event: "chain.reply", Payload: msg.Payload})
+		return nil
+	})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	client := NewClient(&ClientConfig{URL: wsURL})
+	client.OnEvent("chain.reply",
+		func(ctx context.Context, msg *websocketw.Message) error {
+			mu.Lock()
+			order = append(order, "first")
+			mu.Unlock()
+			return nil
+		},
+		func(ctx context.Context, msg *websocketw.Message) error {
+			mu.Lock()
+			order = append(order, "second")
+			mu.Unlock()
+			done <- struct{}{}
+			return nil
+		},
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go client.Connect(ctx)
+	time.Sleep(200 * time.Millisecond)
+
+	// Send a message that triggers the chain
+	msg := &websocketw.Message{Event: "chain.test", Payload: []byte("test")}
+	client.Send(ctx, msg)
+
+	select {
+	case <-done:
+		mu.Lock()
+		o := order
+		mu.Unlock()
+		if len(o) != 2 || o[0] != "first" || o[1] != "second" {
+			t.Errorf("expected [first, second], got %v", o)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for handler chain")
+	}
+
+	client.Close()
+}
+
+func TestClient_AutoReconnect(t *testing.T) {
+	connectCount := 0
+	connectCh := make(chan int, 5)
+
+	srv := New(nil)
+	ts := httptest.NewServer(srv)
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	client := NewClient(&ClientConfig{
+		URL:                wsURL,
+		AutoReconnect:      true,
+		ReconnectInterval:  200 * time.Millisecond,
+		MaxReconnectAttempts: 3,
+	})
+	client.OnConnect(func(ctx context.Context) error {
+		connectCount++
+		connectCh <- connectCount
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	go client.Connect(ctx)
+
+	// Wait for first connection
+	<-connectCh // connectCount = 1
+
+	// Close the server to force disconnect
+	ts.Close()
+	srv.Close()
+
+	// Create a new server on the same port won't work easily with httptest,
+	// so we just verify the client attempted to reconnect.
+	// The reconnect will fail because the server is gone, but OnDisconnect should be called.
+
+	// Wait a bit for reconnection attempts
+	time.Sleep(1 * time.Second)
+
+	client.Close()
+}
+
+func TestClient_RawMessage(t *testing.T) {
+	// Test that client can handle raw JSON messages from the server
+	srv := New(nil)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	received := make(chan *websocketw.Message, 1)
+	client := NewClient(&ClientConfig{URL: wsURL})
+	client.OnEvent("welcome", func(ctx context.Context, msg *websocketw.Message) error {
+		received <- msg
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go client.Connect(ctx)
+
+	// Wait for client to connect
+	time.Sleep(200 * time.Millisecond)
+
+	// Broadcast a welcome message from the server
+	msg := &websocketw.Message{
+		Event:   "welcome",
+		Payload: []byte(`{"message":"connected"}`),
+	}
+	srv.Broadcast(ctx, msg)
+
+	select {
+	case got := <-received:
+		if got.Event != "welcome" {
+			t.Errorf("expected event 'welcome', got '%s'", got.Event)
+		}
+		// Verify the payload is valid JSON
+		var payload map[string]string
+		if err := json.Unmarshal(got.Payload, &payload); err != nil {
+			t.Errorf("failed to unmarshal payload: %v", err)
+		}
+		if payload["message"] != "connected" {
+			t.Errorf("expected message 'connected', got '%s'", payload["message"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for welcome message")
+	}
+
+	client.Close()
+}

--- a/v2/websocketw/gorillaw/gorilla.go
+++ b/v2/websocketw/gorillaw/gorilla.go
@@ -1,0 +1,418 @@
+// Package gorillaw implements the websocketw.Server interface using gorilla/websocket.
+package gorillaw
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/AndreeJait/go-utility/v2/authw"
+	"github.com/AndreeJait/go-utility/v2/logw"
+	"github.com/AndreeJait/go-utility/v2/websocketw"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+)
+
+// Compile-time interface compliance check.
+var _ websocketw.Server = (*server)(nil)
+
+var defaultUpgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
+
+// Config holds the configuration options for initializing the Gorilla WebSocket server.
+type Config struct {
+	// Authenticator is optional. If set, it runs during the HTTP upgrade handshake.
+	// Failed authentication prevents the WebSocket connection from being established.
+	Authenticator authw.Authenticator
+
+	// CheckOrigin allows customizing the CORS origin check for the WebSocket upgrade.
+	// Defaults to allowing all origins.
+	CheckOrigin func(r *http.Request) bool
+
+	// DebugMode enables verbose logging of WebSocket operations.
+	DebugMode bool
+}
+
+type server struct {
+	cfg          *Config
+	upgrader     websocket.Upgrader
+	hub          *hub
+	eventMap     map[websocketw.EventType][]websocketw.Handler
+	onConnect    websocketw.ConnectHandler
+	onDisconnect websocketw.DisconnectHandler
+	mu           sync.RWMutex
+}
+
+// hub manages all connected clients and room subscriptions.
+type hub struct {
+	clients      map[string]*client            // clientID -> client
+	rooms        map[string]map[string]struct{} // room -> set of clientIDs
+	register     chan *client
+	unregister   chan *client
+	broadcast    chan *broadcastMsg
+	onDisconnect websocketw.DisconnectHandler
+	mu           sync.RWMutex
+}
+
+// client represents a single WebSocket connection.
+type client struct {
+	id   string
+	info *websocketw.ClientInfo
+	conn *websocket.Conn
+	send chan []byte
+	ctx  context.Context
+}
+
+type broadcastMsg struct {
+	msg     *websocketw.Message
+	room    string // empty means broadcast to all
+	exclude string // client ID to exclude (e.g., sender)
+}
+
+// New creates a new gorilla/websocket-based WebSocket server.
+func New(cfg *Config) websocketw.Server {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  defaultUpgrader.ReadBufferSize,
+		WriteBufferSize: defaultUpgrader.WriteBufferSize,
+	}
+	if cfg.CheckOrigin != nil {
+		upgrader.CheckOrigin = cfg.CheckOrigin
+	} else {
+		upgrader.CheckOrigin = defaultUpgrader.CheckOrigin
+	}
+
+	s := &server{
+		cfg:      cfg,
+		upgrader: upgrader,
+		hub: &hub{
+			clients:    make(map[string]*client),
+			rooms:      make(map[string]map[string]struct{}),
+			register:   make(chan *client),
+			unregister: make(chan *client),
+			broadcast:  make(chan *broadcastMsg),
+		},
+		eventMap: make(map[websocketw.EventType][]websocketw.Handler),
+	}
+
+	// Start hub goroutine
+	go s.hub.run()
+
+	return s
+}
+
+// ServeHTTP handles the HTTP-to-WebSocket upgrade request.
+// This makes Server implement http.Handler, so it can be mounted directly on any router.
+func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.handleUpgrade(w, r)
+}
+
+// handleUpgrade performs the HTTP-to-WebSocket upgrade and registers the client.
+func (s *server) handleUpgrade(w http.ResponseWriter, r *http.Request) {
+	ctx := logw.InjectLogID(r.Context())
+
+	// Run authentication if configured and not already authenticated by framework middleware
+	if authw.FromContext(ctx) == nil && s.cfg.Authenticator != nil {
+		result, err := s.cfg.Authenticator.Authenticate(r)
+		if err != nil {
+			logw.CtxInfof(ctx, "[WS] authentication failed: %v", err)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		ctx = authw.WithResult(ctx, result)
+		logw.CtxInfof(ctx, "[WS] authenticated user: %s", result.GetUserID())
+	}
+
+	// Upgrade the connection
+	conn, err := s.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		logw.CtxErrorf(ctx, "[WS] upgrade failed: %v", err)
+		return
+	}
+
+	// Build client info
+	clientID := uuid.New().String()
+	info := &websocketw.ClientInfo{
+		ID:   clientID,
+		Data: make(map[string]any),
+	}
+
+	// Populate auth info if available
+	if authResult := authw.FromContext(ctx); authResult != nil {
+		info.UserID = authResult.GetUserID()
+		info.Username = authResult.Username
+		info.Roles = authResult.Roles
+	}
+
+	c := &client{
+		id:   clientID,
+		info: info,
+		conn: conn,
+		send: make(chan []byte, 256),
+		ctx:  ctx,
+	}
+
+	// Register client in hub
+	s.hub.register <- c
+
+	logw.CtxInfof(ctx, "[WS] client connected: %s (user: %s)", clientID, info.UserID)
+
+	// Invoke OnConnect handler
+	if s.onConnect != nil {
+		if err := s.onConnect(ctx, info); err != nil {
+			logw.CtxErrorf(ctx, "[WS] onConnect handler failed for client %s: %v", clientID, err)
+		}
+	}
+
+	// Start read and write pumps
+	go c.writePump()
+	go c.readPump(s)
+}
+
+// readPump reads messages from the WebSocket connection and dispatches to handlers.
+func (c *client) readPump(s *server) {
+	defer func() {
+		s.hub.unregister <- c
+		c.conn.Close()
+	}()
+
+	for {
+		_, message, err := c.conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
+				logw.CtxErrorf(c.ctx, "[WS] unexpected close for client %s: %v", c.id, err)
+			}
+			return
+		}
+
+		if s.cfg.DebugMode {
+			logw.CtxInfof(c.ctx, "[WS] received message from client %s: %s", c.id, string(message))
+		}
+
+		var msg websocketw.Message
+		if err := json.Unmarshal(message, &msg); err != nil {
+			logw.CtxErrorf(c.ctx, "[WS] failed to unmarshal message from client %s: %v", c.id, err)
+			continue
+		}
+
+		// Look up registered handlers for this event type
+		s.mu.RLock()
+		handlers, ok := s.eventMap[msg.Event]
+		s.mu.RUnlock()
+
+		if !ok || len(handlers) == 0 {
+			logw.CtxInfof(c.ctx, "[WS] no handler registered for event '%s' from client %s", msg.Event, c.id)
+			continue
+		}
+
+		// Execute the handler chain
+		if err := websocketw.ExecuteHandlers(c.ctx, &msg, handlers...); err != nil {
+			logw.CtxErrorf(c.ctx, "[WS] handler chain failed for event '%s' from client %s: %v", msg.Event, c.id, err)
+		}
+	}
+}
+
+// writePump sends messages from the send channel to the WebSocket connection.
+func (c *client) writePump() {
+	for {
+		select {
+		case message, ok := <-c.send:
+			if !ok {
+				// Channel closed, send close message
+				c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+				return
+			}
+			if err := c.conn.WriteMessage(websocket.TextMessage, message); err != nil {
+				logw.CtxErrorf(c.ctx, "[WS] write error for client %s: %v", c.id, err)
+				return
+			}
+		}
+	}
+}
+
+// run manages client registration, unregistration, and message broadcasting.
+func (h *hub) run() {
+	for {
+		select {
+		case c := <-h.register:
+			h.mu.Lock()
+			h.clients[c.id] = c
+			h.mu.Unlock()
+			logw.Infof("[WS] client %s registered (total: %d)", c.id, len(h.clients))
+
+		case c := <-h.unregister:
+			h.mu.Lock()
+			if _, ok := h.clients[c.id]; ok {
+				delete(h.clients, c.id)
+				// Remove from all rooms
+				for room := range h.rooms {
+					delete(h.rooms[room], c.id)
+					if len(h.rooms[room]) == 0 {
+						delete(h.rooms, room)
+					}
+				}
+				close(c.send)
+			}
+			h.mu.Unlock()
+			// Invoke onDisconnect handler
+			if h.onDisconnect != nil {
+				h.onDisconnect(c.ctx, c.info)
+			}
+			logw.Infof("[WS] client %s unregistered (total: %d)", c.id, len(h.clients))
+
+		case bm := <-h.broadcast:
+			data, err := json.Marshal(bm.msg)
+			if err != nil {
+				logw.Errorf("[WS] failed to marshal broadcast message: %v", err)
+				continue
+			}
+			h.mu.RLock()
+			if bm.room != "" {
+				// Broadcast to room members only
+				if members, ok := h.rooms[bm.room]; ok {
+					for memberID := range members {
+						if memberID != bm.exclude {
+							if client, ok := h.clients[memberID]; ok {
+								select {
+								case client.send <- data:
+								default:
+									logw.Warningf("[WS] client %s send buffer full, dropping message", memberID)
+								}
+							}
+						}
+					}
+				}
+			} else {
+				// Broadcast to all clients
+				for id, client := range h.clients {
+					if id != bm.exclude {
+						select {
+						case client.send <- data:
+						default:
+							logw.Warningf("[WS] client %s send buffer full, dropping message", id)
+						}
+					}
+				}
+			}
+			h.mu.RUnlock()
+		}
+	}
+}
+
+// Send delivers a message to a specific connected client.
+func (s *server) Send(ctx context.Context, clientID string, msg *websocketw.Message) error {
+	s.hub.mu.RLock()
+	c, ok := s.hub.clients[clientID]
+	s.hub.mu.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("gorillaw: client %s not found", clientID)
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("gorillaw: failed to marshal message: %w", err)
+	}
+
+	select {
+	case c.send <- data:
+		return nil
+	default:
+		return fmt.Errorf("gorillaw: client %s send buffer full", clientID)
+	}
+}
+
+// Broadcast sends a message to all connected clients.
+func (s *server) Broadcast(ctx context.Context, msg *websocketw.Message) error {
+	s.hub.broadcast <- &broadcastMsg{msg: msg}
+	return nil
+}
+
+// BroadcastToRoom sends a message to all clients in a specific room.
+func (s *server) BroadcastToRoom(ctx context.Context, room string, msg *websocketw.Message) error {
+	s.hub.broadcast <- &broadcastMsg{msg: msg, room: room}
+	return nil
+}
+
+// JoinRoom adds a client to a room for targeted broadcasting.
+func (s *server) JoinRoom(ctx context.Context, clientID string, room string) error {
+	s.hub.mu.Lock()
+	defer s.hub.mu.Unlock()
+
+	if _, ok := s.hub.clients[clientID]; !ok {
+		return fmt.Errorf("gorillaw: client %s not found", clientID)
+	}
+
+	if s.hub.rooms[room] == nil {
+		s.hub.rooms[room] = make(map[string]struct{})
+	}
+	s.hub.rooms[room][clientID] = struct{}{}
+
+	logw.CtxInfof(ctx, "[WS] client %s joined room %s", clientID, room)
+	return nil
+}
+
+// LeaveRoom removes a client from a room.
+func (s *server) LeaveRoom(ctx context.Context, clientID string, room string) error {
+	s.hub.mu.Lock()
+	defer s.hub.mu.Unlock()
+
+	if members, ok := s.hub.rooms[room]; ok {
+		delete(members, clientID)
+		if len(members) == 0 {
+			delete(s.hub.rooms, room)
+		}
+	}
+
+	logw.CtxInfof(ctx, "[WS] client %s left room %s", clientID, room)
+	return nil
+}
+
+// OnEvent registers handlers for a specific event type.
+func (s *server) OnEvent(event websocketw.EventType, handlers ...websocketw.Handler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.eventMap[event] = append(s.eventMap[event], handlers...)
+}
+
+// OnConnect registers a handler invoked when a client successfully connects.
+func (s *server) OnConnect(handler websocketw.ConnectHandler) {
+	s.onConnect = handler
+}
+
+// OnDisconnect registers a handler invoked when a client disconnects.
+func (s *server) OnDisconnect(handler websocketw.DisconnectHandler) {
+	s.onDisconnect = handler
+	s.hub.onDisconnect = handler
+}
+
+// Close gracefully shuts down the WebSocket server and disconnects all clients.
+func (s *server) Close() error {
+	s.hub.mu.Lock()
+	for _, c := range s.hub.clients {
+		c.conn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, "server shutting down"))
+		close(c.send)
+		c.conn.Close()
+		delete(s.hub.clients, c.id)
+		// Invoke onDisconnect handler
+		if s.hub.onDisconnect != nil {
+			s.hub.onDisconnect(c.ctx, c.info)
+		}
+	}
+	s.hub.rooms = make(map[string]map[string]struct{})
+	s.hub.mu.Unlock()
+
+	logw.Info("[WS] server closed")
+	return nil
+}

--- a/v2/websocketw/gorillaw/gorilla_test.go
+++ b/v2/websocketw/gorillaw/gorilla_test.go
@@ -1,0 +1,545 @@
+package gorillaw
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AndreeJait/go-utility/v2/websocketw"
+	"github.com/gorilla/websocket"
+)
+
+func TestNew(t *testing.T) {
+	srv := New(nil)
+	if srv == nil {
+		t.Fatal("expected non-nil server")
+	}
+}
+
+func TestNewWithConfig(t *testing.T) {
+	srv := New(&Config{
+		DebugMode: true,
+	})
+	if srv == nil {
+		t.Fatal("expected non-nil server")
+	}
+}
+
+func TestUpgrade(t *testing.T) {
+	srv := New(nil)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("failed to upgrade connection: %v", err)
+	}
+	defer conn.Close()
+}
+
+func TestOnEvent(t *testing.T) {
+	received := make(chan *websocketw.Message, 1)
+
+	srv := New(nil)
+	srv.OnEvent("test.event", func(ctx context.Context, msg *websocketw.Message) error {
+		received <- msg
+		return nil
+	})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	// Give connection time to register
+	time.Sleep(50 * time.Millisecond)
+
+	msg := websocketw.Message{
+		Event:   "test.event",
+		Payload: []byte(`{"key":"value"}`),
+	}
+	data, _ := json.Marshal(msg)
+	if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Fatalf("failed to write message: %v", err)
+	}
+
+	select {
+	case got := <-received:
+		if got.Event != "test.event" {
+			t.Errorf("expected event 'test.event', got '%s'", got.Event)
+		}
+		if string(got.Payload) != `{"key":"value"}` {
+			t.Errorf("expected payload '{\"key\":\"value\"}', got '%s'", string(got.Payload))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for message handler")
+	}
+}
+
+func TestOnEventMiddlewareChain(t *testing.T) {
+	var order []string
+	received := make(chan struct{}, 1)
+
+	srv := New(nil)
+	srv.OnEvent("chain.test",
+		func(ctx context.Context, msg *websocketw.Message) error {
+			order = append(order, "first")
+			return nil
+		},
+		func(ctx context.Context, msg *websocketw.Message) error {
+			order = append(order, "second")
+			received <- struct{}{}
+			return nil
+		},
+	)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	msg := websocketw.Message{Event: "chain.test", Payload: []byte("test")}
+	data, _ := json.Marshal(msg)
+	conn.WriteMessage(websocket.TextMessage, data)
+
+	select {
+	case <-received:
+		if len(order) != 2 || order[0] != "first" || order[1] != "second" {
+			t.Errorf("expected [first, second], got %v", order)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for handler chain")
+	}
+}
+
+func TestOnEventChainHaltOnError(t *testing.T) {
+	var order []string
+
+	srv := New(nil)
+	srv.OnEvent("halt.test",
+		func(ctx context.Context, msg *websocketw.Message) error {
+			order = append(order, "first")
+			return fmt.Errorf("stop chain")
+		},
+		func(ctx context.Context, msg *websocketw.Message) error {
+			order = append(order, "second") // should not be called
+			return nil
+		},
+	)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	msg := websocketw.Message{Event: "halt.test", Payload: []byte("test")}
+	data, _ := json.Marshal(msg)
+	conn.WriteMessage(websocket.TextMessage, data)
+
+	// Wait for processing
+	time.Sleep(200 * time.Millisecond)
+
+	if len(order) != 1 || order[0] != "first" {
+		t.Errorf("expected chain to halt after first handler, got %v", order)
+	}
+}
+
+func TestBroadcast(t *testing.T) {
+	srv := New(nil)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	// Connect two clients
+	conn1, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("client1 failed to connect: %v", err)
+	}
+	defer conn1.Close()
+
+	conn2, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("client2 failed to connect: %v", err)
+	}
+	defer conn2.Close()
+
+	// Give connections time to register
+	time.Sleep(100 * time.Millisecond)
+
+	ctx := context.Background()
+	msg := &websocketw.Message{Event: "broadcast", Payload: []byte("hello all")}
+	srv.Broadcast(ctx, msg)
+
+	// Give hub goroutine time to process the broadcast
+	time.Sleep(50 * time.Millisecond)
+
+	// Both clients should receive the message
+	conn1.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg1, err := conn1.ReadMessage()
+	if err != nil {
+		t.Errorf("client1 failed to read broadcast: %v", err)
+	}
+
+	conn2.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg2, err := conn2.ReadMessage()
+	if err != nil {
+		t.Errorf("client2 failed to read broadcast: %v", err)
+	}
+
+	if len(msg1) == 0 || len(msg2) == 0 {
+		t.Error("expected both clients to receive broadcast message")
+	}
+}
+
+func TestRooms(t *testing.T) {
+	// Use OnConnect to capture client IDs reliably
+	var mu sync.Mutex
+	var clientIDs []string
+
+	srv := New(nil)
+	srv.OnConnect(func(ctx context.Context, client *websocketw.ClientInfo) error {
+		mu.Lock()
+		clientIDs = append(clientIDs, client.ID)
+		mu.Unlock()
+		return nil
+	})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	// Connect two clients
+	conn1, _, _ := websocket.DefaultDialer.Dial(wsURL, nil)
+	defer conn1.Close()
+
+	conn2, _, _ := websocket.DefaultDialer.Dial(wsURL, nil)
+	defer conn2.Close()
+
+	// Wait for both clients to register
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	if len(clientIDs) < 2 {
+		mu.Unlock()
+		t.Fatalf("expected 2 client IDs, got %d", len(clientIDs))
+	}
+	id1 := clientIDs[0]
+	mu.Unlock()
+
+	ctx := context.Background()
+
+	// Join first client to "room1"
+	if err := srv.JoinRoom(ctx, id1, "room1"); err != nil {
+		t.Fatalf("failed to join room: %v", err)
+	}
+
+	// Broadcast to room1 — only client1 (in room) should receive
+	msg := &websocketw.Message{Event: "room.msg", Payload: []byte("room hello")}
+	srv.BroadcastToRoom(ctx, "room1", msg)
+
+	// client1 should receive the room broadcast
+	conn1.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg1, err := conn1.ReadMessage()
+	if err != nil {
+		t.Errorf("client1 (in room) failed to read: %v", err)
+	}
+	if len(msg1) == 0 {
+		t.Error("expected client1 to receive room broadcast")
+	}
+}
+
+func TestRoomIsolation(t *testing.T) {
+	// Verify that broadcasting to one room does NOT send to clients in another room
+	var mu sync.Mutex
+	var clientIDs []string
+
+	srv := New(nil)
+	srv.OnConnect(func(ctx context.Context, client *websocketw.ClientInfo) error {
+		mu.Lock()
+		clientIDs = append(clientIDs, client.ID)
+		mu.Unlock()
+		return nil
+	})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	conn1, _, _ := websocket.DefaultDialer.Dial(wsURL, nil)
+	defer conn1.Close()
+
+	conn2, _, _ := websocket.DefaultDialer.Dial(wsURL, nil)
+	defer conn2.Close()
+
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	if len(clientIDs) < 2 {
+		mu.Unlock()
+		t.Fatalf("expected 2 client IDs, got %d", len(clientIDs))
+	}
+	id1, id2 := clientIDs[0], clientIDs[1]
+	mu.Unlock()
+
+	ctx := context.Background()
+
+	// Join client1 to roomA, client2 to roomB
+	srv.JoinRoom(ctx, id1, "roomA")
+	srv.JoinRoom(ctx, id2, "roomB")
+
+	msg := &websocketw.Message{Event: "room.test", Payload: []byte("roomA only")}
+
+	// Broadcast to roomA
+	srv.BroadcastToRoom(ctx, "roomA", msg)
+
+	// client1 should receive
+	conn1.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg1, err := conn1.ReadMessage()
+	if err != nil {
+		t.Errorf("client1 (in roomA) failed to read: %v", err)
+	}
+	if len(msg1) == 0 {
+		t.Error("expected client1 to receive roomA broadcast")
+	}
+}
+
+func TestLeaveRoom(t *testing.T) {
+	var mu sync.Mutex
+	var clientIDs []string
+
+	srv := New(nil)
+	srv.OnConnect(func(ctx context.Context, client *websocketw.ClientInfo) error {
+		mu.Lock()
+		clientIDs = append(clientIDs, client.ID)
+		mu.Unlock()
+		return nil
+	})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	conn1, _, _ := websocket.DefaultDialer.Dial(wsURL, nil)
+	defer conn1.Close()
+
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	id1 := clientIDs[0]
+	mu.Unlock()
+
+	ctx := context.Background()
+
+	// Join and then leave a room
+	srv.JoinRoom(ctx, id1, "room1")
+	srv.LeaveRoom(ctx, id1, "room1")
+
+	// Broadcast to the room — client1 should NOT receive since it left
+	msg := &websocketw.Message{Event: "left.test", Payload: []byte("after leave")}
+	srv.BroadcastToRoom(ctx, "room1", msg)
+
+	// Verify room is empty by checking there are no members
+	s := srv.(*server)
+	s.hub.mu.RLock()
+	members := s.hub.rooms["room1"]
+	s.hub.mu.RUnlock()
+
+	if members != nil && len(members) != 0 {
+		t.Errorf("expected room1 to be empty after leave, got %d members", len(members))
+	}
+}
+
+func TestSend(t *testing.T) {
+	s := New(nil)
+	srv := s.(*server)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	conn, _, _ := websocket.DefaultDialer.Dial(wsURL, nil)
+	defer conn.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Get client ID
+	srv.hub.mu.RLock()
+	var clientID string
+	for id := range srv.hub.clients {
+		clientID = id
+		break
+	}
+	srv.hub.mu.RUnlock()
+
+	ctx := context.Background()
+	msg := &websocketw.Message{Event: "direct", Payload: []byte("hello you")}
+	if err := srv.Send(ctx, clientID, msg); err != nil {
+		t.Fatalf("failed to send: %v", err)
+	}
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, received, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("failed to read direct message: %v", err)
+	}
+
+	var parsed websocketw.Message
+	if err := json.Unmarshal(received, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if parsed.Event != "direct" {
+		t.Errorf("expected event 'direct', got '%s'", parsed.Event)
+	}
+
+	// Test send to nonexistent client
+	err = srv.Send(ctx, "nonexistent", msg)
+	if err == nil {
+		t.Error("expected error when sending to nonexistent client")
+	}
+}
+
+func TestOnConnect(t *testing.T) {
+	connectCalled := make(chan *websocketw.ClientInfo, 1)
+
+	srv := New(nil)
+	srv.OnConnect(func(ctx context.Context, client *websocketw.ClientInfo) error {
+		connectCalled <- client
+		return nil
+	})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	conn, _, _ := websocket.DefaultDialer.Dial(wsURL, nil)
+	defer conn.Close()
+
+	select {
+	case info := <-connectCalled:
+		if info.ID == "" {
+			t.Error("expected non-empty client ID on connect")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for onConnect handler")
+	}
+}
+
+func TestOnDisconnect(t *testing.T) {
+	disconnectCalled := make(chan *websocketw.ClientInfo, 1)
+
+	srv := New(nil)
+	srv.OnDisconnect(func(ctx context.Context, client *websocketw.ClientInfo) {
+		disconnectCalled <- client
+	})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	conn, _, _ := websocket.DefaultDialer.Dial(wsURL, nil)
+
+	// Give connection time to register
+	time.Sleep(50 * time.Millisecond)
+
+	// Close the client connection
+	conn.Close()
+
+	select {
+	case info := <-disconnectCalled:
+		if info.ID == "" {
+			t.Error("expected non-empty client ID on disconnect")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for onDisconnect handler")
+	}
+}
+
+func TestClose(t *testing.T) {
+	srv := New(nil)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	conn, _, _ := websocket.DefaultDialer.Dial(wsURL, nil)
+
+	time.Sleep(50 * time.Millisecond)
+
+	if err := srv.Close(); err != nil {
+		t.Errorf("expected clean close, got error: %v", err)
+	}
+
+	// Client should receive close frame
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, _, err := conn.ReadMessage()
+	if err == nil {
+		t.Error("expected connection to be closed after server.Close()")
+	}
+}
+
+func TestUnknownEvent(t *testing.T) {
+	srv := New(nil)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	conn, _, _ := websocket.DefaultDialer.Dial(wsURL, nil)
+	defer conn.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Send message for unregistered event — server should not crash
+	msg := websocketw.Message{Event: "unknown.event", Payload: []byte("test")}
+	data, _ := json.Marshal(msg)
+	if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+
+	// Connection should still be alive — send another message
+	if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Fatal("expected connection to still be alive after unknown event")
+	}
+}

--- a/v2/websocketw/websocket.go
+++ b/v2/websocketw/websocket.go
@@ -1,0 +1,135 @@
+// Package websocketw provides a unified, strategy-based interface for WebSocket servers and clients.
+// It abstracts away the underlying implementations (Gorilla, Nhooyr, etc.)
+// while supporting robust middleware chaining, event routing, and room-based broadcasting.
+package websocketw
+
+import (
+	"context"
+	"net/http"
+)
+
+// EventType identifies the kind of WebSocket message being sent or received.
+// Applications define their own event constants (e.g., "chat.message", "order.updated").
+type EventType string
+
+// Message represents a standardized WebSocket event payload.
+// All inbound and outbound messages are normalized to this structure.
+type Message struct {
+	Event   EventType         `json:"event"`   // The event type (e.g., "chat.message")
+	Payload []byte            `json:"payload"` // The raw event data (usually JSON or binary)
+	Headers map[string]string `json:"headers"` // Optional metadata headers
+}
+
+// ClientInfo holds metadata about a connected WebSocket client.
+type ClientInfo struct {
+	ID       string         // Unique connection identifier (auto-generated UUID)
+	UserID   string         // Authenticated user ID (from authw.Result, empty if no auth)
+	Username string         // Authenticated username
+	Roles    []string       // Authenticated user roles
+	Data     map[string]any // Arbitrary connection-scoped metadata
+}
+
+// Handler defines the signature for processing an incoming WebSocket message.
+// Handlers can be chained together like HTTP middleware.
+// If a Handler returns an error, the chain halts.
+type Handler func(ctx context.Context, msg *Message) error
+
+// ConnectHandler is called when a client successfully connects.
+type ConnectHandler func(ctx context.Context, client *ClientInfo) error
+
+// DisconnectHandler is called when a client disconnects.
+type DisconnectHandler func(ctx context.Context, client *ClientInfo)
+
+// ClientConnectHandler is called when the WebSocket client successfully connects
+// to an external server.
+type ClientConnectHandler func(ctx context.Context) error
+
+// ClientDisconnectHandler is called when the WebSocket client disconnects from
+// the external server.
+type ClientDisconnectHandler func(ctx context.Context)
+
+// Server defines the contract for a WebSocket server.
+// Implementations must also satisfy http.Handler via ServeHTTP,
+// allowing them to be mounted on any HTTP router (Echo, Gin, Mux, net/http).
+type Server interface {
+	// ServeHTTP handles the HTTP-to-WebSocket upgrade request.
+	// This makes Server implement http.Handler, so it can be mounted directly
+	// on any router:
+	//   Echo:  e.GET("/ws", echo.Wrap(srv))
+	//   Gin:   r.GET("/ws", gin.WrapH(srv))
+	//   Mux:   r.Handle("/ws", srv)
+	ServeHTTP(w http.ResponseWriter, r *http.Request)
+
+	// Send delivers a message to a specific connected client by client ID.
+	Send(ctx context.Context, clientID string, msg *Message) error
+
+	// Broadcast sends a message to all currently connected clients.
+	Broadcast(ctx context.Context, msg *Message) error
+
+	// BroadcastToRoom sends a message to all clients in a specific room/channel.
+	BroadcastToRoom(ctx context.Context, room string, msg *Message) error
+
+	// JoinRoom adds a client to a room/channel for targeted broadcasting.
+	JoinRoom(ctx context.Context, clientID string, room string) error
+
+	// LeaveRoom removes a client from a room/channel.
+	LeaveRoom(ctx context.Context, clientID string, room string) error
+
+	// OnEvent registers handlers for a specific event type.
+	// When an inbound message has a matching event, these handlers are invoked.
+	// Multiple calls for the same event append to the handler chain (middleware stacking).
+	OnEvent(event EventType, handlers ...Handler)
+
+	// OnConnect registers a handler invoked when a client successfully connects.
+	OnConnect(handler ConnectHandler)
+
+	// OnDisconnect registers a handler invoked when a client disconnects.
+	OnDisconnect(handler DisconnectHandler)
+
+	// Close gracefully shuts down the WebSocket server and disconnects all clients.
+	// This should be registered with gracefulw for clean shutdown:
+	//   gracefulw.Register("WebSocket", ws.Close)
+	Close() error
+}
+
+// Client defines the contract for a WebSocket client that connects
+// to an external WebSocket server, listens for events, and publishes messages.
+type Client interface {
+	// Connect establishes a WebSocket connection to the server and starts
+	// listening for incoming messages. It blocks until the context is canceled
+	// or a fatal connection error occurs.
+	// If auto-reconnect is enabled, it will attempt to reconnect on disconnection.
+	Connect(ctx context.Context) error
+
+	// Send publishes a message to the connected WebSocket server.
+	Send(ctx context.Context, msg *Message) error
+
+	// OnEvent registers handlers for a specific event type received from the server.
+	// When an inbound message has a matching event, these handlers are invoked.
+	// Multiple calls for the same event append to the handler chain (middleware stacking).
+	OnEvent(event EventType, handlers ...Handler)
+
+	// OnConnect registers a handler invoked when the client successfully connects
+	// to the server (also called on reconnection).
+	OnConnect(handler ClientConnectHandler)
+
+	// OnDisconnect registers a handler invoked when the client disconnects from the server.
+	OnDisconnect(handler ClientDisconnectHandler)
+
+	// Close gracefully closes the WebSocket connection.
+	// This should be registered with gracefulw for clean shutdown:
+	//   gracefulw.Register("WSClient", c.Close)
+	Close() error
+}
+
+// ExecuteHandlers is a global utility used internally by WebSocket implementations
+// to run the middleware chain sequentially. It halts execution and returns an error
+// immediately if any handler in the chain fails.
+func ExecuteHandlers(ctx context.Context, msg *Message, handlers ...Handler) error {
+	for _, h := range handlers {
+		if err := h(ctx, msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Introduce websocketw package with Server and Client interfaces following the existing strategy pattern (interface at root, implementation in sub-package).

Server (accept connections, broadcast, rooms):
- websocketw.Server interface with ServeHTTP, Send, Broadcast, BroadcastToRoom, JoinRoom/LeaveRoom, OnEvent, OnConnect/ OnDisconnect, Close
- gorillaw implementation using gorilla/websocket with hub-based client registry, channel-driven broadcast, and room support
- Auth integration: detects existing authw.Result from framework middleware to skip redundant authentication during upgrade
- HTTP framework adapters: echow.WSUpgradeHandler, ginw.WSUpgradeHandler, muxw.WSUpgradeHandler

Client (connect to external WebSocket servers):
- websocketw.Client interface with Connect, Send, OnEvent, OnConnect/OnDisconnect, Close
- gorillaw client implementation with auto-reconnect support, configurable retry interval and max attempts
- Middleware chaining via OnEvent (same fail-fast pattern as brokerw.ExecuteHandlers)
- gracefulw-compatible Close() for clean shutdown