### PR TITLE
Fix v2 versioning and add websocketw docs to README

### DIFF
--- a/.github/workflows/tag-on-push-master.yaml
+++ b/.github/workflows/tag-on-push-master.yaml
@@ -21,69 +21,49 @@ jobs:
       - name: Fetch tags
         run: git fetch --tags --force
 
-      # Prefer git tags over releases/latest (more reliable)
-      - name: Get latest tag (git)
+      - name: Get latest v2 tag
         id: get_latest_tag
         run: |
-          latest_tag=$(git tag --list 'v*' --sort=-v:refname | head -n 1)
+          latest_tag=$(git tag --list 'v2/v2*' --sort=-v:refname | head -n 1)
           echo "latest_tag=$latest_tag" >> "$GITHUB_OUTPUT"
-          echo "Latest tag: ${latest_tag:-<none>}"
+          echo "Latest v2 tag: ${latest_tag:-<none>}"
 
-      - name: Calculate new tag (semver-ish)
+      - name: Calculate new v2 tag
         id: calculate_new_tag
         run: |
           latest_tag="${{ steps.get_latest_tag.outputs.latest_tag }}"
 
           if [ -z "$latest_tag" ]; then
-            new_tag="v0.0.1"
+            new_tag="v2/v2.0.0"
           else
-            version="${latest_tag#v}"
+            # Strip the v2/v2 prefix to get the semver part
+            version="${latest_tag#v2/v2}"
             IFS='.' read -r major minor patch <<< "$version"
 
             major=${major:-0}
             minor=${minor:-0}
             patch=${patch:-0}
 
-            # your logic: patch increments, rollover patch>=9 => minor++, minor>=10 => major++
-            if [ "$patch" -ge 9 ]; then
-              minor=$((minor + 1))
-              patch=0
-            else
-              patch=$((patch + 1))
-            fi
+            patch=$((patch + 1))
 
-            if [ "$minor" -ge 10 ]; then
-              major=$((major + 1))
-              minor=0
-            fi
-
-            new_tag="v$major.$minor.$patch"
+            new_tag="v2/v2.${major}.${minor}.${patch}"
           fi
 
           echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
           echo "Calculated new tag: $new_tag"
 
-      # Keep bumping until we find a tag that doesn't exist on remote
       - name: Ensure tag is unique (remote)
         id: ensure_unique_tag
         run: |
           bump() {
             local tag="$1"
-            local version="${tag#v}"
+            local version="${tag#v2/v2}"
             IFS='.' read -r major minor patch <<< "$version"
             major=${major:-0}; minor=${minor:-0}; patch=${patch:-0}
 
-            if [ "$patch" -ge 9 ]; then
-              minor=$((minor + 1))
-              patch=0
-            else
-              patch=$((patch + 1))
-            fi
-            if [ "$minor" -ge 10 ]; then
-              major=$((major + 1))
-              minor=0
-            fi
-            echo "v$major.$minor.$patch"
+            patch=$((patch + 1))
+
+            echo "v2/v2.${major}.${minor}.${patch}"
           }
 
           candidate="${{ steps.calculate_new_tag.outputs.new_tag }}"
@@ -99,13 +79,13 @@ jobs:
       - name: Configure Git and Create Tag + update latest
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "github-actions[bot]@users.norereply.github.com"
 
           new_tag="${{ steps.ensure_unique_tag.outputs.final_tag }}"
           git tag "$new_tag"
           git push origin "$new_tag"
 
-          # Update the "latest" tag to point to the newly created tag
+          # Update the "latest" tag to point to the same commit
           git tag -f latest "$new_tag"
           git push -f origin latest
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-utility
 
-A collection of production-ready Go utility packages for building backend services — config loading, database wrappers, message brokers, HTTP frameworks, authentication, logging, and more.
+A collection of production-ready Go utility packages for building backend services — config loading, database wrappers, message brokers, HTTP frameworks, authentication, WebSocket, logging, and more.
 
 ## Versions
 
@@ -17,7 +17,7 @@ A collection of production-ready Go utility packages for building backend servic
 
 ```bash
 # v2 (recommended)
-go get github.com/AndreeJait/go-utility/v2@latest
+go get github.com/AndreeJait/go-utility/v2@v2.0.0
 
 # v1 (legacy)
 go get github.com/AndreeJait/go-utility@latest
@@ -354,6 +354,80 @@ consumer.Consume(ctx, "topic", func(ctx context.Context, msg *brokerw.Message) e
 
 Same pattern for `nsqw`, `rabbitmqw`, `rocketmqw` sub-packages.
 
+### WebSocket
+
+**`websocketw`** — WebSocket Server and Client abstraction with event routing, room support, and auto-reconnect.
+
+```go
+import "github.com/AndreeJait/go-utility/v2/websocketw"
+import "github.com/AndreeJait/go-utility/v2/websocketw/gorillaw"
+```
+
+**Server** — Accept connections, broadcast, and handle events with rooms:
+
+```go
+ws := gorillaw.New(&gorillaw.Config{
+    Authenticator: jwtAuth,  // optional: auth during upgrade
+})
+
+// Handle incoming events
+ws.OnEvent("chat.message", func(ctx context.Context, msg *websocketw.Message) error {
+    ws.Broadcast(ctx, msg)
+    return nil
+})
+
+// Lifecycle hooks
+ws.OnConnect(func(ctx context.Context, client *websocketw.ClientInfo) error {
+    ws.JoinRoom(ctx, client.ID, "lobby")
+    return nil
+})
+ws.OnDisconnect(func(ctx context.Context, client *websocketw.ClientInfo) {
+    // cleanup
+})
+
+// Mount on any httpw router
+e.GET("/ws", echow.WSUpgradeHandler(ws))      // Echo
+r.GET("/ws", ginw.WSUpgradeHandler(ws))       // Gin
+r.HandleFunc("/ws", muxw.WSUpgradeHandler(ws)) // Mux
+
+// Room-based broadcasting
+ws.BroadcastToRoom(ctx, "lobby", &websocketw.Message{Event: "user.joined", Payload: payload})
+
+// Graceful shutdown
+gracefulw.Register("WebSocket", ws.Close)
+```
+
+**Client** — Connect to an external WebSocket server, listen for events, and publish:
+
+```go
+client := gorillaw.NewClient(&gorillaw.ClientConfig{
+    URL:                "wss://external-server.com/ws",
+    Header:             http.Header{"Authorization": {"Bearer token"}},
+    AutoReconnect:      true,
+    ReconnectInterval:  3 * time.Second,
+    MaxReconnectAttempts: 5,  // 0 = unlimited
+})
+
+// Listen for events (middleware chaining supported)
+client.OnEvent("order.updated", func(ctx context.Context, msg *websocketw.Message) error {
+    // handle event
+    return nil
+})
+
+// Lifecycle hooks
+client.OnConnect(func(ctx context.Context) error { return nil })
+client.OnDisconnect(func(ctx context.Context) {})
+
+// Connect blocks until context is canceled or fatal error
+go client.Connect(ctx)
+
+// Send messages to the server
+client.Send(ctx, &websocketw.Message{Event: "chat.message", Payload: payload})
+
+// Graceful shutdown
+gracefulw.Register("WSClient", client.Close)
+```
+
 ### Cloud Storage
 
 **`storagew`** — Storage abstraction with MinIO, AWS S3, GCS, and Huawei OBS.
@@ -509,6 +583,7 @@ Every major v2 capability is defined by an interface at the package root, with c
 brokerw.Producer / Consumer  →  kafkaw, nsqw, rabbitmqw, rocketmqw
 storagew.Storage             →  miniow, awsw, gcsw, huaweiw
 botw.Bot                     →  discordw, telegramw
+websocketw.Server / Client   →  gorillaw
 authw.Authenticator          →  jwt.go, basic.go
 authw.Cache                 →  localCache (localcachew), redisCache (go-redis)
 ```
@@ -576,10 +651,12 @@ cd v2 && go mod tidy && go mod vendor
 ## Release
 
 Pushing to `master` automatically triggers the CI workflow (`.github/workflows/tag-on-push-master.yaml`) which:
-1. Calculates the next semver tag (patch bump; patch >= 9 rolls to minor; minor >= 10 rolls to major)
+1. Calculates the next `v2/v2.x.y` semver tag for the v2 subdirectory module
 2. Creates and pushes the tag
 3. Generates a changelog from commit messages
 4. Creates a GitHub Release
+
+Tags follow Go's subdirectory module convention: `v2/v2.0.0`, `v2/v2.0.1`, etc. This allows `go get github.com/AndreeJait/go-utility/v2@v2.0.0` to resolve correctly via the Go module proxy.
 
 ## License
 


### PR DESCRIPTION
- CI: Update tag format from v0.x.y to v2/v2.x.y for proper Go subdirectory module resolution. The v2 module at v2/go.mod requires tags prefixed with v2/ for go get to resolve versions correctly. First v2 tag will be v2/v2.0.0.
- README: Add websocketw package documentation covering Server (accept connections, broadcast, rooms, auth integration, framework adapters) and Client (connect to external servers, event routing, auto-reconnect).
- README: Update installation to reference v2.0.0, update architecture diagram to include websocketw, and update release process docs.