### PR TITLE
Add generic value helpers to valuew package

### DIFF
--- a/v2/valuew/value.go
+++ b/v2/valuew/value.go
@@ -14,3 +14,112 @@ func Coalesce[T comparable](vals ...T) T {
 	}
 	return zero
 }
+
+// --- Pointer Helpers ---
+
+// Ptr returns a pointer to v. Useful for creating pointer literals
+// without a helper variable: Ptr(42) instead of v := 42; &v.
+func Ptr[T any](v T) *T {
+	return &v
+}
+
+// Deref safely dereferences a pointer, returning the fallback value if p is nil.
+// If no fallback is provided, returns the zero value of T.
+func Deref[T any](p *T, fallback ...T) T {
+	if p != nil {
+		return *p
+	}
+	if len(fallback) > 0 {
+		return fallback[0]
+	}
+	var zero T
+	return zero
+}
+
+// DerefZero safely dereferences a pointer, returning the zero value of T if p is nil.
+func DerefZero[T any](p *T) T {
+	if p != nil {
+		return *p
+	}
+	var zero T
+	return zero
+}
+
+// IsNil reports whether p is nil.
+func IsNil[T any](p *T) bool {
+	return p == nil
+}
+
+// EqualPtr reports whether two pointer values are equal.
+// nil pointers are considered equal to each other.
+// A nil pointer is never equal to a non-nil pointer.
+func EqualPtr[T comparable](a, b *T) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+// --- Conversion Helpers ---
+
+// ToAny converts v to the any (interface{}) type.
+// Useful for converting []T to []any in variadic calls.
+func ToAny[T any](v T) any {
+	return v
+}
+
+// FromAny type-asserts v to T, returning fallback if the assertion fails.
+// If no fallback is provided, returns the zero value of T.
+func FromAny[T any](v any, fallback ...T) T {
+	if t, ok := v.(T); ok {
+		return t
+	}
+	if len(fallback) > 0 {
+		return fallback[0]
+	}
+	var zero T
+	return zero
+}
+
+// --- Slice/Map Helpers ---
+
+// CoalesceSlice returns the first non-nil, non-empty slice from the given slices.
+// If all slices are nil or empty, returns nil.
+func CoalesceSlice[T any](slices ...[]T) []T {
+	for _, s := range slices {
+		if len(s) > 0 {
+			return s
+		}
+	}
+	return nil
+}
+
+// Contains reports whether v is present in s.
+func Contains[S ~[]E, E comparable](s S, v E) bool {
+	for _, e := range s {
+		if e == v {
+			return true
+		}
+	}
+	return false
+}
+
+// MapKeys returns the keys of m as a slice.
+// The order is unspecified.
+func MapKeys[M ~map[K]V, K comparable, V any](m M) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// MapValues returns the values of m as a slice.
+// The order is unspecified.
+func MapValues[M ~map[K]V, K comparable, V any](m M) []V {
+	values := make([]V, 0, len(m))
+	for _, v := range m {
+		values = append(values, v)
+	}
+	return values
+}

--- a/v2/valuew/value_test.go
+++ b/v2/valuew/value_test.go
@@ -79,3 +79,314 @@ func TestCoalesceFloat(t *testing.T) {
 		t.Errorf("Coalesce(0.0, 0.3) = %v, want 0.3", got)
 	}
 }
+
+// --- Pointer Helpers ---
+
+func TestPtr(t *testing.T) {
+	tests := []struct {
+		name  string
+		input int
+		want  int
+	}{
+		{"int zero", 0, 0},
+		{"int positive", 42, 42},
+		{"int negative", -1, -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Ptr(tt.input)
+			if got == nil {
+				t.Fatal("Ptr returned nil")
+			}
+			if *got != tt.want {
+				t.Errorf("Ptr(%d) = %d, want %d", tt.input, *got, tt.want)
+			}
+		})
+	}
+
+	t.Run("string", func(t *testing.T) {
+		p := Ptr("hello")
+		if p == nil || *p != "hello" {
+			t.Errorf("Ptr(\"hello\") = %v, want \"hello\"", p)
+		}
+	})
+
+	t.Run("bool", func(t *testing.T) {
+		p := Ptr(true)
+		if p == nil || *p != true {
+			t.Errorf("Ptr(true) = %v, want true", p)
+		}
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		p := Ptr(3.14)
+		if p == nil || *p != 3.14 {
+			t.Errorf("Ptr(3.14) = %v, want 3.14", p)
+		}
+	})
+}
+
+func TestDeref(t *testing.T) {
+	t.Run("non-nil pointer", func(t *testing.T) {
+		v := 42
+		if got := Deref(&v); got != 42 {
+			t.Errorf("Deref(&42) = %d, want 42", got)
+		}
+	})
+
+	t.Run("nil pointer with fallback", func(t *testing.T) {
+		var p *int
+		if got := Deref(p, 99); got != 99 {
+			t.Errorf("Deref(nil, 99) = %d, want 99", got)
+		}
+	})
+
+	t.Run("nil pointer without fallback returns zero", func(t *testing.T) {
+		var p *int
+		if got := Deref(p); got != 0 {
+			t.Errorf("Deref(nil) = %d, want 0", got)
+		}
+	})
+
+	t.Run("string with fallback", func(t *testing.T) {
+		var p *string
+		if got := Deref(p, "default"); got != "default" {
+			t.Errorf("Deref(nil, \"default\") = %q, want \"default\"", got)
+		}
+	})
+
+	t.Run("non-nil ignores fallback", func(t *testing.T) {
+		v := "actual"
+		if got := Deref(&v, "fallback"); got != "actual" {
+			t.Errorf("Deref(&\"actual\", \"fallback\") = %q, want \"actual\"", got)
+		}
+	})
+}
+
+func TestDerefZero(t *testing.T) {
+	t.Run("non-nil pointer", func(t *testing.T) {
+		v := 42
+		if got := DerefZero(&v); got != 42 {
+			t.Errorf("DerefZero(&42) = %d, want 42", got)
+		}
+	})
+
+	t.Run("nil pointer returns zero", func(t *testing.T) {
+		var p *int
+		if got := DerefZero(p); got != 0 {
+			t.Errorf("DerefZero(nil) = %d, want 0", got)
+		}
+	})
+
+	t.Run("nil string pointer returns empty", func(t *testing.T) {
+		var p *string
+		if got := DerefZero(p); got != "" {
+			t.Errorf("DerefZero(nil) = %q, want \"\"", got)
+		}
+	})
+}
+
+func TestIsNil(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var p *int
+		if !IsNil(p) {
+			t.Error("IsNil(nil) = false, want true")
+		}
+	})
+
+	t.Run("non-nil pointer", func(t *testing.T) {
+		v := 42
+		if IsNil(&v) {
+			t.Error("IsNil(&42) = true, want false")
+		}
+	})
+}
+
+func TestEqualPtr(t *testing.T) {
+	t.Run("both nil", func(t *testing.T) {
+		if !EqualPtr[int](nil, nil) {
+			t.Error("EqualPtr(nil, nil) = false, want true")
+		}
+	})
+
+	t.Run("one nil", func(t *testing.T) {
+		v := 42
+		if EqualPtr(&v, nil) {
+			t.Error("EqualPtr(&42, nil) = true, want false")
+		}
+		if EqualPtr(nil, &v) {
+			t.Error("EqualPtr(nil, &42) = true, want false")
+		}
+	})
+
+	t.Run("equal values", func(t *testing.T) {
+		a, b := 42, 42
+		if !EqualPtr(&a, &b) {
+			t.Error("EqualPtr(&42, &42) = false, want true")
+		}
+	})
+
+	t.Run("unequal values", func(t *testing.T) {
+		a, b := 42, 99
+		if EqualPtr(&a, &b) {
+			t.Error("EqualPtr(&42, &99) = true, want false")
+		}
+	})
+}
+
+// --- Conversion Helpers ---
+
+func TestToAny(t *testing.T) {
+	if got := ToAny(42); got != 42 {
+		t.Errorf("ToAny(42) = %v, want 42", got)
+	}
+	if got := ToAny("hello"); got != "hello" {
+		t.Errorf("ToAny(\"hello\") = %v, want \"hello\"", got)
+	}
+}
+
+func TestFromAny(t *testing.T) {
+	t.Run("successful assertion", func(t *testing.T) {
+		var v any = 42
+		if got := FromAny[int](v); got != 42 {
+			t.Errorf("FromAny[int](42) = %d, want 42", got)
+		}
+	})
+
+	t.Run("failed assertion with fallback", func(t *testing.T) {
+		var v any = "hello"
+		if got := FromAny[int](v, 99); got != 99 {
+			t.Errorf("FromAny[int](\"hello\", 99) = %d, want 99", got)
+		}
+	})
+
+	t.Run("failed assertion without fallback returns zero", func(t *testing.T) {
+		var v any = "hello"
+		if got := FromAny[int](v); got != 0 {
+			t.Errorf("FromAny[int](\"hello\") = %d, want 0", got)
+		}
+	})
+
+	t.Run("nil value with fallback", func(t *testing.T) {
+		if got := FromAny[string](nil, "default"); got != "default" {
+			t.Errorf("FromAny[string](nil, \"default\") = %q, want \"default\"", got)
+		}
+	})
+}
+
+// --- Slice/Map Helpers ---
+
+func TestCoalesceSlice(t *testing.T) {
+	t.Run("first non-empty", func(t *testing.T) {
+		a := []int{1, 2}
+		b := []int{3, 4}
+		if got := CoalesceSlice(a, b); len(got) != 2 || got[0] != 1 {
+			t.Errorf("CoalesceSlice(%v, %v) = %v, want [1 2]", a, b, got)
+		}
+	})
+
+	t.Run("first nil second non-empty", func(t *testing.T) {
+		var a []int
+		b := []int{3, 4}
+		if got := CoalesceSlice(a, b); len(got) != 2 || got[0] != 3 {
+			t.Errorf("CoalesceSlice(nil, %v) = %v, want [3 4]", b, got)
+		}
+	})
+
+	t.Run("first empty second non-empty", func(t *testing.T) {
+		a := []int{}
+		b := []int{3, 4}
+		if got := CoalesceSlice(a, b); len(got) != 2 || got[0] != 3 {
+			t.Errorf("CoalesceSlice([], %v) = %v, want [3 4]", b, got)
+		}
+	})
+
+	t.Run("all nil returns nil", func(t *testing.T) {
+		var a, b []int
+		if got := CoalesceSlice(a, b); got != nil {
+			t.Errorf("CoalesceSlice(nil, nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("no args returns nil", func(t *testing.T) {
+		if got := CoalesceSlice[int](); got != nil {
+			t.Errorf("CoalesceSlice() = %v, want nil", got)
+		}
+	})
+}
+
+func TestContains(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		if !Contains([]string{"a", "b", "c"}, "b") {
+			t.Error("Contains([a b c], b) = false, want true")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		if Contains([]string{"a", "b", "c"}, "d") {
+			t.Error("Contains([a b c], d) = true, want false")
+		}
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		if Contains([]string{}, "a") {
+			t.Error("Contains([], a) = true, want false")
+		}
+	})
+
+	t.Run("int slice", func(t *testing.T) {
+		if !Contains([]int{1, 2, 3}, 2) {
+			t.Error("Contains([1 2 3], 2) = false, want true")
+		}
+	})
+}
+
+func TestMapKeys(t *testing.T) {
+	m := map[string]int{"a": 1, "b": 2, "c": 3}
+	keys := MapKeys(m)
+	if len(keys) != 3 {
+		t.Errorf("MapKeys returned %d keys, want 3", len(keys))
+	}
+	// Check all keys are present
+	keySet := map[string]bool{}
+	for _, k := range keys {
+		keySet[k] = true
+	}
+	for _, want := range []string{"a", "b", "c"} {
+		if !keySet[want] {
+			t.Errorf("missing key %q", want)
+		}
+	}
+}
+
+func TestMapValues(t *testing.T) {
+	m := map[string]int{"a": 1, "b": 2, "c": 3}
+	values := MapValues(m)
+	if len(values) != 3 {
+		t.Errorf("MapValues returned %d values, want 3", len(values))
+	}
+	// Check all values are present
+	sum := 0
+	for _, v := range values {
+		sum += v
+	}
+	if sum != 6 {
+		t.Errorf("MapValues sum = %d, want 6", sum)
+	}
+}
+
+func TestMapKeysEmpty(t *testing.T) {
+	m := map[string]int{}
+	keys := MapKeys(m)
+	if len(keys) != 0 {
+		t.Errorf("MapKeys of empty map = %v, want []", keys)
+	}
+}
+
+func TestMapValuesEmpty(t *testing.T) {
+	m := map[string]int{}
+	values := MapValues(m)
+	if len(values) != 0 {
+		t.Errorf("MapValues of empty map = %v, want []", values)
+	}
+}


### PR DESCRIPTION
  - Ptr[T]: pointer literal helper (replaces StrPtr/IntPtr/etc.)
  - Deref[T]: safe dereference with optional fallback
  - DerefZero[T]: dereference or return zero value
  - IsNil[T]: explicit nil check for typed pointers
  - EqualPtr[T]: nil-safe pointer comparison
  - ToAny[T]: value-to-any conversion
  - FromAny[T]: type-assert with fallback
  - CoalesceSlice[T]: first non-nil/non-empty slice
  - Contains[S, E]: generic slice contains
  - MapKeys[M]: extract map keys as slice
  - MapValues[M]: extract map values as slice