### PR TITLE
feat: add gcpw package for GCP identity token authentication

### DIFF
--- a/v2/brokerw/nsqw/nsq.go
+++ b/v2/brokerw/nsqw/nsq.go
@@ -99,6 +99,7 @@ func (p *nsqProducer) Close() error {
 // nsqConsumer implements brokerw.Consumer for NSQ.
 type nsqConsumer struct {
 	lookupdAddrs []string
+	nsqdAddr     string
 	channel      string
 	consumers    []*nsq.Consumer
 }
@@ -110,6 +111,17 @@ func NewConsumer(lookupdAddrs []string, channel string) brokerw.Consumer {
 	return &nsqConsumer{
 		lookupdAddrs: lookupdAddrs,
 		channel:      channel,
+	}
+}
+
+// NewConsumerDirect initializes an NSQ consumer that connects directly to nsqd.
+// This is useful when nsqlookupd broadcast address isn't resolvable from the client.
+// The 'channel' acts as a consumer group; every consumer in the same channel
+// shares the message load for a topic.
+func NewConsumerDirect(nsqdAddr, channel string) brokerw.Consumer {
+	return &nsqConsumer{
+		nsqdAddr: nsqdAddr,
+		channel:  channel,
 	}
 }
 
@@ -143,9 +155,19 @@ func (c *nsqConsumer) Consume(ctx context.Context, topic string, handlers ...bro
 		return nil // Returning nil tells NSQ to Ack the message
 	}))
 
-	// Connect to the lookup daemons to discover nsqd nodes dynamically
-	if err := q.ConnectToNSQLookupds(c.lookupdAddrs); err != nil {
-		return err
+	// Connect either directly to nsqd or via lookupd
+	if c.nsqdAddr != "" {
+		// Direct connection to nsqd
+		if err := q.ConnectToNSQD(c.nsqdAddr); err != nil {
+			return err
+		}
+		logw.Infof("nsqw: connected directly to nsqd %s", c.nsqdAddr)
+	} else if len(c.lookupdAddrs) > 0 {
+		// Connect to lookupd for dynamic discovery
+		if err := q.ConnectToNSQLookupds(c.lookupdAddrs); err != nil {
+			return err
+		}
+		logw.Infof("nsqw: querying nsqlookupd %v", c.lookupdAddrs)
 	}
 
 	c.consumers = append(c.consumers, q)

--- a/v2/gcpw/gcloud.go
+++ b/v2/gcpw/gcloud.go
@@ -1,0 +1,144 @@
+package gcpw
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/AndreeJait/go-utility/v2/logw"
+)
+
+// GCloudConfig holds configuration for the gcloud CLI-based token provider.
+type GCloudConfig struct {
+	// GCloudBin is the path to the gcloud binary. Defaults to "gcloud" if empty.
+	GCloudBin string
+
+	// DebugMode enables verbose logging of token operations.
+	DebugMode bool
+}
+
+type gcloudTokenProvider struct {
+	bin   string
+	debug bool
+
+	mu        sync.Mutex
+	cachedTok *Token
+}
+
+// NewGCloudTokenProvider creates a TokenProvider that obtains identity tokens
+// by executing "gcloud auth print-identity-token". Tokens are cached and
+// automatically refreshed 5 minutes before expiry.
+//
+// This is a convenience for local development where gcloud CLI is already
+// authenticated. For production workloads, use NewIdentityTokenProvider instead.
+func NewGCloudTokenProvider(cfg *GCloudConfig) TokenProvider {
+	if cfg == nil {
+		cfg = &GCloudConfig{}
+	}
+	bin := cfg.GCloudBin
+	if bin == "" {
+		bin = "gcloud"
+	}
+	return &gcloudTokenProvider{
+		bin:   bin,
+		debug: cfg.DebugMode,
+	}
+}
+
+func (p *gcloudTokenProvider) Token(ctx context.Context) (*Token, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Return cached token if still valid (with 5-minute refresh window).
+	if p.cachedTok != nil && time.Now().Before(p.cachedTok.Expiry.Add(-5*time.Minute)) {
+		if p.debug {
+			logw.CtxInfof(ctx, "gcpw: returning cached gcloud identity token (expires=%s)", p.cachedTok.Expiry)
+		}
+		return p.cachedTok, nil
+	}
+
+	if p.debug {
+		logw.CtxInfof(ctx, "gcpw: fetching new gcloud identity token via %s", p.bin)
+	}
+
+	cmd := exec.CommandContext(ctx, p.bin, "auth", "print-identity-token")
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("gcpw: gcloud auth print-identity-token failed: %s", strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return nil, fmt.Errorf("gcpw: gcloud auth print-identity-token: %w", err)
+	}
+
+	raw := strings.TrimSpace(string(out))
+
+	expiry, err := parseJWTExpiry(raw)
+	if err != nil {
+		if p.debug {
+			logw.CtxInfof(ctx, "gcpw: could not parse token expiry, using 55-minute default: %v", err)
+		}
+		// Tokens from gcloud typically expire in 1 hour; use 55 minutes as safe default.
+		expiry = time.Now().Add(55 * time.Minute)
+	}
+
+	tok := &Token{
+		Value:  raw,
+		Type:   "Bearer",
+		Expiry: expiry,
+	}
+
+	p.cachedTok = tok
+
+	if p.debug {
+		logw.CtxInfof(ctx, "gcpw: gcloud identity token obtained (expires=%s)", tok.Expiry)
+	}
+
+	return tok, nil
+}
+
+func (p *gcloudTokenProvider) Close() error {
+	if p.debug {
+		logw.Infof("gcpw: gcloud token provider closed")
+	}
+	return nil
+}
+
+var _ TokenProvider = (*gcloudTokenProvider)(nil)
+
+// jwtClaims represents the payload of a JWT token.
+type jwtClaims struct {
+	Exp int64 `json:"exp"`
+}
+
+// parseJWTExpiry extracts the expiry time from a JWT without verifying the signature.
+func parseJWTExpiry(token string) (time.Time, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return time.Time{}, fmt.Errorf("gcpw: invalid JWT format: expected 3 parts, got %d", len(parts))
+	}
+
+	payload, err := base64.RawStdEncoding.DecodeString(parts[1])
+	if err != nil {
+		// Try URL-safe encoding.
+		payload, err = base64.RawURLEncoding.DecodeString(parts[1])
+		if err != nil {
+			return time.Time{}, fmt.Errorf("gcpw: failed to decode JWT payload: %w", err)
+		}
+	}
+
+	var claims jwtClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return time.Time{}, fmt.Errorf("gcpw: failed to parse JWT claims: %w", err)
+	}
+
+	if claims.Exp == 0 {
+		return time.Time{}, fmt.Errorf("gcpw: JWT has no exp claim")
+	}
+
+	return time.Unix(claims.Exp, 0), nil
+}

--- a/v2/gcpw/gcp.go
+++ b/v2/gcpw/gcp.go
@@ -1,0 +1,66 @@
+package gcpw
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Token represents an authentication token obtained from a GCP auth source.
+type Token struct {
+	Value  string
+	Type   string
+	Expiry time.Time
+}
+
+// TokenProvider defines the contract for obtaining GCP authentication tokens.
+// Implementations must be safe for concurrent use.
+type TokenProvider interface {
+	Token(ctx context.Context) (*Token, error)
+	Close() error
+}
+
+// AuthenticatedHTTPClient returns an *http.Client that automatically attaches
+// the Authorization header to every outgoing request using the given TokenProvider.
+// If base is nil, http.DefaultClient is used as the starting point.
+func AuthenticatedHTTPClient(tp TokenProvider, base *http.Client) *http.Client {
+	if base == nil {
+		base = http.DefaultClient
+	}
+
+	baseTransport := base.Transport
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+
+	return &http.Client{
+		Transport: &authTransport{
+			base: baseTransport,
+			tp:   tp,
+		},
+		Timeout: base.Timeout,
+	}
+}
+
+type authTransport struct {
+	base http.RoundTripper
+	tp   TokenProvider
+}
+
+func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, err := t.tp.Token(req.Context())
+	if err != nil {
+		return nil, fmt.Errorf("gcpw: failed to get token for request: %w", err)
+	}
+
+	req2 := req.Clone(req.Context())
+
+	tokenType := token.Type
+	if tokenType == "" {
+		tokenType = "Bearer"
+	}
+	req2.Header.Set("Authorization", tokenType+" "+token.Value)
+
+	return t.base.RoundTrip(req2)
+}

--- a/v2/gcpw/identity.go
+++ b/v2/gcpw/identity.go
@@ -1,0 +1,106 @@
+package gcpw
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/auth"
+	"cloud.google.com/go/auth/credentials/idtoken"
+
+	"github.com/AndreeJait/go-utility/v2/logw"
+)
+
+// IdentityConfig holds the configuration for the GCP identity token provider.
+type IdentityConfig struct {
+	// Audience is the target service URL for the identity token (e.g., "https://my-service-abc123.run.app").
+	// Required.
+	Audience string
+
+	// CredentialsFile is the path to a service account JSON key file.
+	// If empty, Application Default Credentials are used.
+	CredentialsFile string
+
+	// CredentialsJSON is the raw bytes of a service account JSON key file.
+	// If set, CredentialsFile must be empty.
+	CredentialsJSON []byte
+
+	// CustomClaims are extra JWT claims to include in the identity token.
+	CustomClaims map[string]interface{}
+
+	// DebugMode enables verbose logging of token operations.
+	DebugMode bool
+}
+
+type identityTokenProvider struct {
+	creds    *auth.Credentials
+	audience string
+	debug    bool
+}
+
+// NewIdentityTokenProvider creates a TokenProvider that obtains OIDC identity tokens
+// from GCP Application Default Credentials for the given audience.
+//
+// On Compute Engine/Cloud Run, it fetches identity tokens from the metadata server.
+// With a service account JSON file, it self-signs a JWT and exchanges it via the
+// OAuth2 token endpoint. Tokens are automatically cached and refreshed before expiry.
+func NewIdentityTokenProvider(ctx context.Context, cfg *IdentityConfig) (TokenProvider, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("gcpw: identity config is required")
+	}
+	if cfg.Audience == "" {
+		return nil, fmt.Errorf("gcpw: audience is required for identity tokens")
+	}
+
+	opts := &idtoken.Options{
+		Audience:     cfg.Audience,
+		CustomClaims: cfg.CustomClaims,
+	}
+
+	if cfg.CredentialsFile != "" {
+		opts.CredentialsFile = cfg.CredentialsFile
+	}
+	if len(cfg.CredentialsJSON) > 0 {
+		opts.CredentialsJSON = cfg.CredentialsJSON
+	}
+
+	creds, err := idtoken.NewCredentials(opts)
+	if err != nil {
+		return nil, fmt.Errorf("gcpw: failed to create identity token credentials: %w", err)
+	}
+
+	if cfg.DebugMode {
+		logw.Infof("gcpw: identity token provider initialized for audience %q", cfg.Audience)
+	}
+
+	return &identityTokenProvider{
+		creds:    creds,
+		audience: cfg.Audience,
+		debug:    cfg.DebugMode,
+	}, nil
+}
+
+func (p *identityTokenProvider) Token(ctx context.Context) (*Token, error) {
+	sdkToken, err := p.creds.Token(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("gcpw: failed to obtain identity token: %w", err)
+	}
+
+	if p.debug {
+		logw.CtxInfof(ctx, "gcpw: identity token obtained (expires=%s)", sdkToken.Expiry)
+	}
+
+	return &Token{
+		Value:  sdkToken.Value,
+		Type:   sdkToken.Type,
+		Expiry: sdkToken.Expiry,
+	}, nil
+}
+
+func (p *identityTokenProvider) Close() error {
+	if p.debug {
+		logw.Infof("gcpw: identity token provider closed for audience %q", p.audience)
+	}
+	return nil
+}
+
+var _ TokenProvider = (*identityTokenProvider)(nil)

--- a/v2/gcpw/identity_test.go
+++ b/v2/gcpw/identity_test.go
@@ -1,0 +1,336 @@
+package gcpw
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewIdentityTokenProvider_NilConfig(t *testing.T) {
+	_, err := NewIdentityTokenProvider(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil config")
+	}
+	if !strings.Contains(err.Error(), "gcpw: identity config is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNewIdentityTokenProvider_EmptyAudience(t *testing.T) {
+	_, err := NewIdentityTokenProvider(context.Background(), &IdentityConfig{})
+	if err == nil {
+		t.Fatal("expected error for empty audience")
+	}
+	if !strings.Contains(err.Error(), "gcpw: audience is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNewIdentityTokenProvider_InvalidCredentials(t *testing.T) {
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/nonexistent/path/to/credentials.json")
+
+	_, err := NewIdentityTokenProvider(context.Background(), &IdentityConfig{
+		Audience: "https://example.run.app",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid credentials path")
+	}
+	if !strings.Contains(err.Error(), "gcpw: failed to create identity token credentials") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+type mockTokenProvider struct {
+	token *Token
+	err   error
+}
+
+func (m *mockTokenProvider) Token(_ context.Context) (*Token, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.token, nil
+}
+
+func (m *mockTokenProvider) Close() error { return nil }
+
+func TestAuthenticatedHTTPClient_SetsAuthHeader(t *testing.T) {
+	var capturedReq *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedReq = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tp := &mockTokenProvider{
+		token: &Token{Value: "test-id-token", Type: "Bearer"},
+	}
+
+	client := AuthenticatedHTTPClient(tp, nil)
+	resp, err := client.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if capturedReq == nil {
+		t.Fatal("request was not captured")
+	}
+
+	auth := capturedReq.Header.Get("Authorization")
+	if auth != "Bearer test-id-token" {
+		t.Errorf("Authorization header = %q, want %q", auth, "Bearer test-id-token")
+	}
+}
+
+func TestAuthenticatedHTTPClient_ClonesRequest(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tp := &mockTokenProvider{
+		token: &Token{Value: "test-id-token", Type: "Bearer"},
+	}
+
+	client := AuthenticatedHTTPClient(tp, nil)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
+	req.Header.Set("X-Custom", "original")
+	originalAuth := req.Header.Get("Authorization")
+
+	_, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if req.Header.Get("Authorization") != originalAuth {
+		t.Error("original request was modified by the transport")
+	}
+	if req.Header.Get("X-Custom") != "original" {
+		t.Error("original request custom header was modified")
+	}
+}
+
+func TestAuthenticatedHTTPClient_TokenError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tp := &mockTokenProvider{
+		err: errors.New("token service unavailable"),
+	}
+
+	client := AuthenticatedHTTPClient(tp, nil)
+	_, err := client.Get(ts.URL)
+	if err == nil {
+		t.Fatal("expected error when token provider fails")
+	}
+	if !strings.Contains(err.Error(), "gcpw: failed to get token for request") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestAuthenticatedHTTPClient_CustomTokenType(t *testing.T) {
+	var capturedReq *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedReq = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tp := &mockTokenProvider{
+		token: &Token{Value: "test-token", Type: "MAC"},
+	}
+
+	client := AuthenticatedHTTPClient(tp, nil)
+	resp, err := client.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	auth := capturedReq.Header.Get("Authorization")
+	if auth != "MAC test-token" {
+		t.Errorf("Authorization header = %q, want %q", auth, "MAC test-token")
+	}
+}
+
+func TestAuthenticatedHTTPClient_EmptyTypeDefaultsBearer(t *testing.T) {
+	var capturedReq *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedReq = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tp := &mockTokenProvider{
+		token: &Token{Value: "test-token", Type: ""},
+	}
+
+	client := AuthenticatedHTTPClient(tp, nil)
+	resp, err := client.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	auth := capturedReq.Header.Get("Authorization")
+	if auth != "Bearer test-token" {
+		t.Errorf("Authorization header = %q, want %q", auth, "Bearer test-token")
+	}
+}
+
+func TestAuthenticatedHTTPClient_NilBaseClient(t *testing.T) {
+	tp := &mockTokenProvider{
+		token: &Token{Value: "test-token", Type: "Bearer"},
+	}
+
+	client := AuthenticatedHTTPClient(tp, nil)
+	if client == nil {
+		t.Fatal("client is nil")
+	}
+	if client.Transport == nil {
+		t.Fatal("transport is nil")
+	}
+	if _, ok := client.Transport.(*authTransport); !ok {
+		t.Errorf("transport type = %T, want *authTransport", client.Transport)
+	}
+}
+
+func TestToken_ExpiryField(t *testing.T) {
+	now := time.Now()
+	tok := &Token{
+		Value:  "test-token",
+		Type:   "Bearer",
+		Expiry: now,
+	}
+	if tok.Expiry != now {
+		t.Errorf("Expiry = %v, want %v", tok.Expiry, now)
+	}
+}
+
+func TestGCloudTokenProvider_NilConfig(t *testing.T) {
+	tp := NewGCloudTokenProvider(nil)
+	if tp == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
+func TestGCloudTokenProvider_DefaultBin(t *testing.T) {
+	provider := NewGCloudTokenProvider(&GCloudConfig{})
+	gp := provider.(*gcloudTokenProvider)
+	if gp.bin != "gcloud" {
+		t.Errorf("default bin = %q, want %q", gp.bin, "gcloud")
+	}
+}
+
+func TestGCloudTokenProvider_CustomBin(t *testing.T) {
+	provider := NewGCloudTokenProvider(&GCloudConfig{GCloudBin: "/usr/local/bin/gcloud"})
+	gp := provider.(*gcloudTokenProvider)
+	if gp.bin != "/usr/local/bin/gcloud" {
+		t.Errorf("custom bin = %q, want %q", gp.bin, "/usr/local/bin/gcloud")
+	}
+}
+
+func TestGCloudTokenProvider_CommandFails(t *testing.T) {
+	tp := NewGCloudTokenProvider(&GCloudConfig{
+		GCloudBin: "/nonexistent/gcloud",
+	})
+	defer tp.Close()
+
+	_, err := tp.Token(context.Background())
+	if err == nil {
+		t.Fatal("expected error for nonexistent gcloud binary")
+	}
+	if !strings.Contains(err.Error(), "gcpw:") {
+		t.Errorf("error should be prefixed with gcpw:, got: %v", err)
+	}
+}
+
+func TestGCloudTokenProvider_CachesToken(t *testing.T) {
+	expiry := time.Now().Add(1 * time.Hour)
+	freshTok := &Token{Value: "cached-token", Type: "Bearer", Expiry: expiry}
+
+	provider := &gcloudTokenProvider{bin: "gcloud", cachedTok: freshTok}
+
+	// Should return cached token without calling gcloud.
+	tok, err := provider.Token(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok.Value != "cached-token" {
+		t.Errorf("token = %q, want %q", tok.Value, "cached-token")
+	}
+}
+
+func TestGCloudTokenProvider_RefreshesExpiredToken(t *testing.T) {
+	expiredTok := &Token{Value: "expired-token", Type: "Bearer", Expiry: time.Now().Add(-1 * time.Minute)}
+
+	provider := &gcloudTokenProvider{bin: "/nonexistent/gcloud", cachedTok: expiredTok}
+
+	// Expired token should attempt refresh (which fails because bin doesn't exist).
+	_, err := provider.Token(context.Background())
+	if err == nil {
+		t.Fatal("expected error when refreshing expired token with bad binary")
+	}
+}
+
+func TestParseJWTExpiry_Valid(t *testing.T) {
+	expiry := time.Now().Add(1*time.Hour).Unix()
+	claims := map[string]interface{}{"exp": float64(expiry)}
+	payload, _ := json.Marshal(claims)
+	encoded := base64.RawURLEncoding.EncodeToString(payload)
+	token := "header." + encoded + ".signature"
+
+	got, err := parseJWTExpiry(token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Unix() != expiry {
+		t.Errorf("expiry = %v, want %v", got.Unix(), expiry)
+	}
+}
+
+func TestParseJWTExpiry_NoExpClaim(t *testing.T) {
+	claims := map[string]interface{}{"sub": "test"}
+	payload, _ := json.Marshal(claims)
+	encoded := base64.RawURLEncoding.EncodeToString(payload)
+	token := "header." + encoded + ".signature"
+
+	_, err := parseJWTExpiry(token)
+	if err == nil {
+		t.Fatal("expected error for JWT without exp claim")
+	}
+}
+
+func TestParseJWTExpiry_InvalidFormat(t *testing.T) {
+	_, err := parseJWTExpiry("not-a-jwt")
+	if err == nil {
+		t.Fatal("expected error for invalid JWT format")
+	}
+}
+
+func TestParseJWTExpiry_StandardBase64(t *testing.T) {
+	expiry := time.Now().Add(1*time.Hour).Unix()
+	claims := map[string]interface{}{"exp": float64(expiry)}
+	payload, _ := json.Marshal(claims)
+	// Use standard base64 (with padding) instead of URL-safe.
+	encoded := base64.RawStdEncoding.EncodeToString(payload)
+	token := "header." + encoded + ".signature"
+
+	got, err := parseJWTExpiry(token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Unix() != expiry {
+		t.Errorf("expiry = %v, want %v", got.Unix(), expiry)
+	}
+}

--- a/v2/gcpw/integration_test.go
+++ b/v2/gcpw/integration_test.go
@@ -1,0 +1,55 @@
+//go:build integration
+
+package gcpw
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+const testAudience = ""
+
+// TestIntegration_InvokeOllama_GCloud calls the Cloud Run Ollama service using
+// an identity token obtained via "gcloud auth print-identity-token".
+//
+// Prerequisites:
+//   - gcloud CLI installed and authenticated (gcloud auth login)
+//   - The gcloud account must have roles/run.invoker on the target service
+//
+// Run:
+//
+//	cd v2 && go test ./gcpw/ -tags=integration -run TestIntegration_InvokeOllama_GCloud -v -timeout 120s
+func TestIntegration_InvokeOllama_GCloud(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	tp := NewGCloudTokenProvider(nil)
+	defer tp.Close()
+
+	client := AuthenticatedHTTPClient(tp, &http.Client{Timeout: 90 * time.Second})
+
+	body := bytes.NewBufferString(`{"model":"qwen3.5:9b","prompt":"Hello this is testing! can you answer this question for me?","stream":false}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, testAudience+"/api/generate", body)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	t.Logf("response status: %d", resp.StatusCode)
+	t.Logf("response body: %s", string(respBody))
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -3,6 +3,7 @@ module github.com/AndreeJait/go-utility/v2
 go 1.25.0
 
 require (
+	cloud.google.com/go/auth v0.18.1
 	cloud.google.com/go/storage v1.60.0
 	github.com/apache/rocketmq-client-go/v2 v2.1.2
 	github.com/aws/aws-sdk-go-v2 v1.41.3
@@ -46,7 +47,6 @@ require (
 require (
 	cel.dev/expr v0.24.0 // indirect
 	cloud.google.com/go v0.123.0 // indirect
-	cloud.google.com/go/auth v0.18.1 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.5.3 // indirect


### PR DESCRIPTION
  - Add TokenProvider interface and AuthenticatedHTTPClient utility (gcp.go)
  - Add NewIdentityTokenProvider using cloud.google.com/go/auth/credentials/idtoken for ADC/service account/compute metadata server auth (identity.go)
  - Add NewGCloudTokenProvider using gcloud CLI for local development (gcloud.go)
  - Token caching with 5-minute refresh window and JWT expiry parsing
  - Promote cloud.google.com/go/auth from indirect to direct dependency