### PR TITLE
feat: add cloudflarw and tuyaw packages for Cloudflare and Tuya IoT API wrappers

### DIFF
--- a/v2/cloudflarw/apiv4w/apiv4.go
+++ b/v2/cloudflarw/apiv4w/apiv4.go
@@ -1,0 +1,513 @@
+package apiv4w
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/AndreeJait/go-utility/v2/cloudflarw"
+)
+
+const defaultBaseURL = "https://api.cloudflare.com/client/v4"
+
+// Config holds the configuration for the Cloudflare API v4 client.
+type Config struct {
+	// APIToken is the Cloudflare API Bearer token. Required.
+	APIToken string
+
+	// AccountID is the default account ID used when accountID is not passed
+	// explicitly to tunnel and access methods. Optional.
+	AccountID string
+
+	// BaseURL overrides the Cloudflare API base URL.
+	// Defaults to "https://api.cloudflare.com/client/v4" if empty.
+	BaseURL string
+
+	// HTTPClient is an optional custom HTTP client. If nil, http.DefaultClient is used.
+	HTTPClient *http.Client
+
+	// DebugMode enables verbose logging of API requests and responses.
+	DebugMode bool
+}
+
+type cfClient struct {
+	client    *http.Client
+	baseURL   string
+	token     string
+	accountID string
+	debug     bool
+}
+
+var _ cloudflarw.Cloudflare = (*cfClient)(nil)
+
+// New creates a new Cloudflare API v4 client from the given config.
+func New(cfg *Config) (cloudflarw.Cloudflare, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("apiv4w: config is required")
+	}
+	if cfg.APIToken == "" {
+		return nil, fmt.Errorf("apiv4w: api token is required")
+	}
+
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	client := cfg.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	return &cfClient{
+		client:    client,
+		baseURL:   baseURL,
+		token:     cfg.APIToken,
+		accountID: cfg.AccountID,
+		debug:     cfg.DebugMode,
+	}, nil
+}
+
+// --- API response envelope ---
+
+type apiResponse struct {
+	Success    bool                       `json:"success"`
+	Errors     []apiError                 `json:"errors"`
+	Messages   []apiMessage               `json:"messages"`
+	Result     json.RawMessage            `json:"result"`
+	ResultInfo *cloudflarw.ListResultInfo  `json:"result_info,omitempty"`
+}
+
+type apiError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type apiMessage struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// --- Internal helpers ---
+
+func (c *cfClient) doRequest(ctx context.Context, method, path string, body io.Reader) (json.RawMessage, *cloudflarw.ListResultInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("apiv4w: creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("apiv4w: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("apiv4w: reading response: %w", err)
+	}
+
+	var apiResp apiResponse
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return nil, nil, fmt.Errorf("apiv4w: decoding response: %w", err)
+	}
+
+	if !apiResp.Success {
+		var errMsgs []string
+		for _, e := range apiResp.Errors {
+			errMsgs = append(errMsgs, fmt.Sprintf("%d: %s", e.Code, e.Message))
+		}
+		return nil, nil, fmt.Errorf("apiv4w: api error: %s", strings.Join(errMsgs, "; "))
+	}
+
+	return apiResp.Result, apiResp.ResultInfo, nil
+}
+
+func (c *cfClient) resolveAccountID(accountID string) (string, error) {
+	if accountID != "" {
+		return accountID, nil
+	}
+	if c.accountID != "" {
+		return c.accountID, nil
+	}
+	return "", fmt.Errorf("apiv4w: account id is required")
+}
+
+// --- Accounts ---
+
+func (c *cfClient) ListAccounts(ctx context.Context) ([]cloudflarw.Account, *cloudflarw.ListResultInfo, error) {
+	result, info, err := c.doRequest(ctx, http.MethodGet, "/accounts", nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("apiv4w: list accounts: %w", err)
+	}
+
+	var accounts []cloudflarw.Account
+	if err := json.Unmarshal(result, &accounts); err != nil {
+		return nil, nil, fmt.Errorf("apiv4w: decoding accounts: %w", err)
+	}
+	return accounts, info, nil
+}
+
+// --- Zones ---
+
+func (c *cfClient) ListZones(ctx context.Context) ([]cloudflarw.Zone, *cloudflarw.ListResultInfo, error) {
+	result, info, err := c.doRequest(ctx, http.MethodGet, "/zones", nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("apiv4w: list zones: %w", err)
+	}
+
+	var zones []cloudflarw.Zone
+	if err := json.Unmarshal(result, &zones); err != nil {
+		return nil, nil, fmt.Errorf("apiv4w: decoding zones: %w", err)
+	}
+	return zones, info, nil
+}
+
+func (c *cfClient) GetZone(ctx context.Context, zoneID string) (*cloudflarw.Zone, error) {
+	result, _, err := c.doRequest(ctx, http.MethodGet, "/zones/"+zoneID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: get zone: %w", err)
+	}
+
+	var zone cloudflarw.Zone
+	if err := json.Unmarshal(result, &zone); err != nil {
+		return nil, fmt.Errorf("apiv4w: decoding zone: %w", err)
+	}
+	return &zone, nil
+}
+
+// --- DNS Records ---
+
+func (c *cfClient) ListDNSRecords(ctx context.Context, zoneID string) ([]cloudflarw.DNSRecord, *cloudflarw.ListResultInfo, error) {
+	result, info, err := c.doRequest(ctx, http.MethodGet, "/zones/"+zoneID+"/dns_records", nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("apiv4w: list dns records: %w", err)
+	}
+
+	var records []cloudflarw.DNSRecord
+	if err := json.Unmarshal(result, &records); err != nil {
+		return nil, nil, fmt.Errorf("apiv4w: decoding dns records: %w", err)
+	}
+	return records, info, nil
+}
+
+func (c *cfClient) GetDNSRecord(ctx context.Context, zoneID, recordID string) (*cloudflarw.DNSRecord, error) {
+	result, _, err := c.doRequest(ctx, http.MethodGet, "/zones/"+zoneID+"/dns_records/"+recordID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: get dns record: %w", err)
+	}
+
+	var record cloudflarw.DNSRecord
+	if err := json.Unmarshal(result, &record); err != nil {
+		return nil, fmt.Errorf("apiv4w: decoding dns record: %w", err)
+	}
+	return &record, nil
+}
+
+func (c *cfClient) CreateDNSRecord(ctx context.Context, zoneID string, record *cloudflarw.DNSRecord) (*cloudflarw.DNSRecord, error) {
+	body, err := json.Marshal(record)
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: marshal dns record: %w", err)
+	}
+
+	result, _, err := c.doRequest(ctx, http.MethodPost, "/zones/"+zoneID+"/dns_records", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: create dns record: %w", err)
+	}
+
+	var created cloudflarw.DNSRecord
+	if err := json.Unmarshal(result, &created); err != nil {
+		return nil, fmt.Errorf("apiv4w: decoding created dns record: %w", err)
+	}
+	return &created, nil
+}
+
+func (c *cfClient) UpdateDNSRecord(ctx context.Context, zoneID, recordID string, record *cloudflarw.DNSRecord) (*cloudflarw.DNSRecord, error) {
+	body, err := json.Marshal(record)
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: marshal dns record: %w", err)
+	}
+
+	result, _, err := c.doRequest(ctx, http.MethodPatch, "/zones/"+zoneID+"/dns_records/"+recordID, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: update dns record: %w", err)
+	}
+
+	var updated cloudflarw.DNSRecord
+	if err := json.Unmarshal(result, &updated); err != nil {
+		return nil, fmt.Errorf("apiv4w: decoding updated dns record: %w", err)
+	}
+	return &updated, nil
+}
+
+func (c *cfClient) DeleteDNSRecord(ctx context.Context, zoneID, recordID string) error {
+	_, _, err := c.doRequest(ctx, http.MethodDelete, "/zones/"+zoneID+"/dns_records/"+recordID, nil)
+	if err != nil {
+		return fmt.Errorf("apiv4w: delete dns record: %w", err)
+	}
+	return nil
+}
+
+// --- Tunnels ---
+
+func (c *cfClient) ListTunnels(ctx context.Context, accountID string) ([]cloudflarw.Tunnel, *cloudflarw.ListResultInfo, error) {
+	resolved, err := c.resolveAccountID(accountID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("apiv4w: list tunnels: %w", err)
+	}
+
+	result, info, err := c.doRequest(ctx, http.MethodGet, "/accounts/"+resolved+"/cfd_tunnel", nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("apiv4w: list tunnels: %w", err)
+	}
+
+	var tunnels []cloudflarw.Tunnel
+	if err := json.Unmarshal(result, &tunnels); err != nil {
+		return nil, nil, fmt.Errorf("apiv4w: decoding tunnels: %w", err)
+	}
+	return tunnels, info, nil
+}
+
+func (c *cfClient) GetTunnel(ctx context.Context, accountID, tunnelID string) (*cloudflarw.Tunnel, error) {
+	resolved, err := c.resolveAccountID(accountID)
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: get tunnel: %w", err)
+	}
+
+	result, _, err := c.doRequest(ctx, http.MethodGet, "/accounts/"+resolved+"/cfd_tunnel/"+tunnelID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: get tunnel: %w", err)
+	}
+
+	var tunnel cloudflarw.Tunnel
+	if err := json.Unmarshal(result, &tunnel); err != nil {
+		return nil, fmt.Errorf("apiv4w: decoding tunnel: %w", err)
+	}
+	return &tunnel, nil
+}
+
+type createTunnelRequest struct {
+	Name       string `json:"name"`
+	TunnelType string `json:"tunnel_type"`
+}
+
+func (c *cfClient) CreateTunnel(ctx context.Context, accountID, name, tunnelType string) (*cloudflarw.Tunnel, error) {
+	resolved, err := c.resolveAccountID(accountID)
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: create tunnel: %w", err)
+	}
+
+	body, err := json.Marshal(createTunnelRequest{Name: name, TunnelType: tunnelType})
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: marshal create tunnel: %w", err)
+	}
+
+	result, _, err := c.doRequest(ctx, http.MethodPost, "/accounts/"+resolved+"/cfd_tunnel", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: create tunnel: %w", err)
+	}
+
+	var tunnel cloudflarw.Tunnel
+	if err := json.Unmarshal(result, &tunnel); err != nil {
+		return nil, fmt.Errorf("apiv4w: decoding created tunnel: %w", err)
+	}
+	return &tunnel, nil
+}
+
+type updateTunnelRequest struct {
+	Name         string `json:"name,omitempty"`
+	TunnelSecret string `json:"tunnel_secret,omitempty"`
+}
+
+func (c *cfClient) UpdateTunnel(ctx context.Context, accountID, tunnelID string, tunnel *cloudflarw.Tunnel) (*cloudflarw.Tunnel, error) {
+	resolved, err := c.resolveAccountID(accountID)
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: update tunnel: %w", err)
+	}
+
+	body, err := json.Marshal(updateTunnelRequest{Name: tunnel.Name})
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: marshal update tunnel: %w", err)
+	}
+
+	result, _, err := c.doRequest(ctx, http.MethodPatch, "/accounts/"+resolved+"/cfd_tunnel/"+tunnelID, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: update tunnel: %w", err)
+	}
+
+	var updated cloudflarw.Tunnel
+	if err := json.Unmarshal(result, &updated); err != nil {
+		return nil, fmt.Errorf("apiv4w: decoding updated tunnel: %w", err)
+	}
+	return &updated, nil
+}
+
+func (c *cfClient) DeleteTunnel(ctx context.Context, accountID, tunnelID string) error {
+	resolved, err := c.resolveAccountID(accountID)
+	if err != nil {
+		return fmt.Errorf("apiv4w: delete tunnel: %w", err)
+	}
+
+	_, _, err = c.doRequest(ctx, http.MethodDelete, "/accounts/"+resolved+"/cfd_tunnel/"+tunnelID, nil)
+	if err != nil {
+		return fmt.Errorf("apiv4w: delete tunnel: %w", err)
+	}
+	return nil
+}
+
+func (c *cfClient) GetTunnelConfig(ctx context.Context, accountID, tunnelID string) (*cloudflarw.TunnelConfig, error) {
+	resolved, err := c.resolveAccountID(accountID)
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: get tunnel config: %w", err)
+	}
+
+	result, _, err := c.doRequest(ctx, http.MethodGet, "/accounts/"+resolved+"/cfd_tunnel/"+tunnelID+"/configurations", nil)
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: get tunnel config: %w", err)
+	}
+
+	var config cloudflarw.TunnelConfig
+	if err := json.Unmarshal(result, &config); err != nil {
+		return nil, fmt.Errorf("apiv4w: decoding tunnel config: %w", err)
+	}
+	return &config, nil
+}
+
+func (c *cfClient) UpdateTunnelConfig(ctx context.Context, accountID, tunnelID string, config *cloudflarw.TunnelConfig) error {
+	resolved, err := c.resolveAccountID(accountID)
+	if err != nil {
+		return fmt.Errorf("apiv4w: update tunnel config: %w", err)
+	}
+
+	body, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("apiv4w: marshal tunnel config: %w", err)
+	}
+
+	_, _, err = c.doRequest(ctx, http.MethodPut, "/accounts/"+resolved+"/cfd_tunnel/"+tunnelID+"/configurations", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("apiv4w: update tunnel config: %w", err)
+	}
+	return nil
+}
+
+func (c *cfClient) GetTunnelToken(ctx context.Context, accountID, tunnelID string) (string, error) {
+	resolved, err := c.resolveAccountID(accountID)
+	if err != nil {
+		return "", fmt.Errorf("apiv4w: get tunnel token: %w", err)
+	}
+
+	result, _, err := c.doRequest(ctx, http.MethodGet, "/accounts/"+resolved+"/cfd_tunnel/"+tunnelID+"/token", nil)
+	if err != nil {
+		return "", fmt.Errorf("apiv4w: get tunnel token: %w", err)
+	}
+
+	var token string
+	if err := json.Unmarshal(result, &token); err != nil {
+		return "", fmt.Errorf("apiv4w: decoding tunnel token: %w", err)
+	}
+	return token, nil
+}
+
+// --- Access Applications ---
+
+func (c *cfClient) ListAccessApps(ctx context.Context, accountID string) ([]cloudflarw.AccessApp, *cloudflarw.ListResultInfo, error) {
+	resolved, err := c.resolveAccountID(accountID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("apiv4w: list access apps: %w", err)
+	}
+
+	result, info, err := c.doRequest(ctx, http.MethodGet, "/accounts/"+resolved+"/access/apps", nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("apiv4w: list access apps: %w", err)
+	}
+
+	var apps []cloudflarw.AccessApp
+	if err := json.Unmarshal(result, &apps); err != nil {
+		return nil, nil, fmt.Errorf("apiv4w: decoding access apps: %w", err)
+	}
+	return apps, info, nil
+}
+
+func (c *cfClient) GetAccessApp(ctx context.Context, accountID, appID string) (*cloudflarw.AccessApp, error) {
+	resolved, err := c.resolveAccountID(accountID)
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: get access app: %w", err)
+	}
+
+	result, _, err := c.doRequest(ctx, http.MethodGet, "/accounts/"+resolved+"/access/apps/"+appID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: get access app: %w", err)
+	}
+
+	var app cloudflarw.AccessApp
+	if err := json.Unmarshal(result, &app); err != nil {
+		return nil, fmt.Errorf("apiv4w: decoding access app: %w", err)
+	}
+	return &app, nil
+}
+
+func (c *cfClient) CreateAccessApp(ctx context.Context, accountID string, app *cloudflarw.AccessApp) (*cloudflarw.AccessApp, error) {
+	resolved, err := c.resolveAccountID(accountID)
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: create access app: %w", err)
+	}
+
+	body, err := json.Marshal(app)
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: marshal access app: %w", err)
+	}
+
+	result, _, err := c.doRequest(ctx, http.MethodPost, "/accounts/"+resolved+"/access/apps", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: create access app: %w", err)
+	}
+
+	var created cloudflarw.AccessApp
+	if err := json.Unmarshal(result, &created); err != nil {
+		return nil, fmt.Errorf("apiv4w: decoding created access app: %w", err)
+	}
+	return &created, nil
+}
+
+func (c *cfClient) UpdateAccessApp(ctx context.Context, accountID, appID string, app *cloudflarw.AccessApp) (*cloudflarw.AccessApp, error) {
+	resolved, err := c.resolveAccountID(accountID)
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: update access app: %w", err)
+	}
+
+	body, err := json.Marshal(app)
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: marshal access app: %w", err)
+	}
+
+	result, _, err := c.doRequest(ctx, http.MethodPut, "/accounts/"+resolved+"/access/apps/"+appID, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("apiv4w: update access app: %w", err)
+	}
+
+	var updated cloudflarw.AccessApp
+	if err := json.Unmarshal(result, &updated); err != nil {
+		return nil, fmt.Errorf("apiv4w: decoding updated access app: %w", err)
+	}
+	return &updated, nil
+}
+
+func (c *cfClient) DeleteAccessApp(ctx context.Context, accountID, appID string) error {
+	resolved, err := c.resolveAccountID(accountID)
+	if err != nil {
+		return fmt.Errorf("apiv4w: delete access app: %w", err)
+	}
+
+	_, _, err = c.doRequest(ctx, http.MethodDelete, "/accounts/"+resolved+"/access/apps/"+appID, nil)
+	if err != nil {
+		return fmt.Errorf("apiv4w: delete access app: %w", err)
+	}
+	return nil
+}

--- a/v2/cloudflarw/apiv4w/apiv4_test.go
+++ b/v2/cloudflarw/apiv4w/apiv4_test.go
@@ -1,0 +1,865 @@
+package apiv4w
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/AndreeJait/go-utility/v2/cloudflarw"
+)
+
+// --- Interface compliance ---
+
+func TestInterfaceCompliance(t *testing.T) {
+	var _ cloudflarw.Cloudflare = (*cfClient)(nil)
+}
+
+// --- Constructor tests ---
+
+func TestNew_NilConfig(t *testing.T) {
+	_, err := New(nil)
+	if err == nil {
+		t.Fatal("expected error for nil config")
+	}
+	if !strings.Contains(err.Error(), "config is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNew_EmptyToken(t *testing.T) {
+	_, err := New(&Config{APIToken: ""})
+	if err == nil {
+		t.Fatal("expected error for empty token")
+	}
+	if !strings.Contains(err.Error(), "api token is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNew_ValidConfig(t *testing.T) {
+	cf, err := New(&Config{APIToken: "test-token"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cf == nil {
+		t.Fatal("expected non-nil client")
+	}
+}
+
+func TestNew_DefaultBaseURL(t *testing.T) {
+	client, err := New(&Config{APIToken: "test-token"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := client.(*cfClient)
+	if c.baseURL != defaultBaseURL {
+		t.Fatalf("expected default base URL %q, got %q", defaultBaseURL, c.baseURL)
+	}
+}
+
+func TestNew_CustomBaseURL(t *testing.T) {
+	client, err := New(&Config{APIToken: "test-token", BaseURL: "https://custom.api.url"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := client.(*cfClient)
+	if c.baseURL != "https://custom.api.url" {
+		t.Fatalf("expected custom base URL, got %q", c.baseURL)
+	}
+}
+
+func TestNew_DefaultAccountID(t *testing.T) {
+	client, err := New(&Config{APIToken: "test-token", AccountID: "acc-123"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := client.(*cfClient)
+	if c.accountID != "acc-123" {
+		t.Fatalf("expected account ID acc-123, got %q", c.accountID)
+	}
+}
+
+// --- resolveAccountID tests ---
+
+func TestResolveAccountID_Explicit(t *testing.T) {
+	c := &cfClient{accountID: "default"}
+	resolved, err := c.resolveAccountID("explicit")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved != "explicit" {
+		t.Fatalf("expected explicit, got %q", resolved)
+	}
+}
+
+func TestResolveAccountID_Fallback(t *testing.T) {
+	c := &cfClient{accountID: "default"}
+	resolved, err := c.resolveAccountID("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved != "default" {
+		t.Fatalf("expected default, got %q", resolved)
+	}
+}
+
+func TestResolveAccountID_Empty(t *testing.T) {
+	c := &cfClient{}
+	_, err := c.resolveAccountID("")
+	if err == nil {
+		t.Fatal("expected error for empty account ID")
+	}
+	if !strings.Contains(err.Error(), "account id is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// --- Helper to create test server and client ---
+
+func newTestClient(handler http.HandlerFunc) (cloudflarw.Cloudflare, *httptest.Server) {
+	ts := httptest.NewServer(handler)
+	cf, _ := New(&Config{
+		APIToken: "test-token",
+		BaseURL:  ts.URL,
+	})
+	return cf, ts
+}
+
+func envelope(result any, success bool, errors ...apiError) map[string]any {
+	return map[string]any{
+		"success": success,
+		"errors":  errors,
+		"result":  result,
+	}
+}
+
+func envelopeWithInfo(result any, info *cloudflarw.ListResultInfo) map[string]any {
+	return map[string]any{
+		"success":     true,
+		"errors":      []any{},
+		"result":      result,
+		"result_info": info,
+	}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	w.Write(data)
+}
+
+// --- Accounts ---
+
+func TestListAccounts_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/accounts" {
+			t.Fatalf("expected /accounts, got %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Fatalf("expected Bearer test-token, got %s", r.Header.Get("Authorization"))
+		}
+		writeJSON(t, w, envelopeWithInfo([]map[string]string{
+			{"id": "acc-1", "name": "My Account", "type": "standard"},
+		}, &cloudflarw.ListResultInfo{Count: 1, Page: 1, PerPage: 20, TotalCount: 1}))
+	})
+	defer ts.Close()
+
+	accounts, info, err := cf.ListAccounts(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("expected 1 account, got %d", len(accounts))
+	}
+	if accounts[0].ID != "acc-1" {
+		t.Fatalf("expected acc-1, got %s", accounts[0].ID)
+	}
+	if info == nil || info.TotalCount != 1 {
+		t.Fatalf("expected total_count 1, got %+v", info)
+	}
+}
+
+func TestListAccounts_APIError(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, envelope(nil, false, apiError{Code: 1000, Message: "invalid token"}))
+	})
+	defer ts.Close()
+
+	_, _, err := cf.ListAccounts(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "1000: invalid token") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// --- Zones ---
+
+func TestListZones_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/zones" {
+			t.Fatalf("expected /zones, got %s", r.URL.Path)
+		}
+		writeJSON(t, w, envelopeWithInfo([]map[string]any{
+			{"id": "zone-1", "name": "example.com", "status": "active", "account": map[string]string{"id": "acc-1", "name": "My Account"}},
+		}, &cloudflarw.ListResultInfo{Count: 1, TotalCount: 1}))
+	})
+	defer ts.Close()
+
+	zones, _, err := cf.ListZones(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(zones) != 1 {
+		t.Fatalf("expected 1 zone, got %d", len(zones))
+	}
+	if zones[0].Name != "example.com" {
+		t.Fatalf("expected example.com, got %s", zones[0].Name)
+	}
+}
+
+func TestGetZone_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/zones/zone-1" {
+			t.Fatalf("expected /zones/zone-1, got %s", r.URL.Path)
+		}
+		writeJSON(t, w, envelope(map[string]any{
+			"id": "zone-1", "name": "example.com", "status": "active", "account": map[string]string{"id": "acc-1"},
+		}, true))
+	})
+	defer ts.Close()
+
+	zone, err := cf.GetZone(context.Background(), "zone-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if zone.ID != "zone-1" {
+		t.Fatalf("expected zone-1, got %s", zone.ID)
+	}
+}
+
+// --- DNS Records ---
+
+func TestListDNSRecords_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/zones/zone-1/dns_records" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		writeJSON(t, w, envelopeWithInfo([]map[string]any{
+			{"id": "rec-1", "type": "A", "name": "www.example.com", "content": "1.2.3.4", "proxied": true, "ttl": 1},
+		}, &cloudflarw.ListResultInfo{Count: 1, TotalCount: 1}))
+	})
+	defer ts.Close()
+
+	records, _, err := cf.ListDNSRecords(context.Background(), "zone-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	if records[0].Type != "A" || records[0].Content != "1.2.3.4" {
+		t.Fatalf("unexpected record: %+v", records[0])
+	}
+}
+
+func TestGetDNSRecord_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, envelope(map[string]any{
+			"id": "rec-1", "type": "CNAME", "name": "app.example.com", "content": "target.example.com", "proxied": false, "ttl": 3600,
+		}, true))
+	})
+	defer ts.Close()
+
+	record, err := cf.GetDNSRecord(context.Background(), "zone-1", "rec-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if record.Type != "CNAME" {
+		t.Fatalf("expected CNAME, got %s", record.Type)
+	}
+}
+
+func TestCreateDNSRecord_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		json.Unmarshal(body, &req)
+		if req["type"] != "TXT" {
+			t.Fatalf("expected type TXT, got %v", req["type"])
+		}
+
+		writeJSON(t, w, envelope(map[string]any{
+			"id": "rec-new", "type": "TXT", "name": "_test.example.com", "content": "test-value", "proxied": false, "ttl": 120,
+		}, true))
+	})
+	defer ts.Close()
+
+	record, err := cf.CreateDNSRecord(context.Background(), "zone-1", &cloudflarw.DNSRecord{
+		Type: "TXT", Name: "_test.example.com", Content: "test-value", TTL: 120,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if record.ID != "rec-new" {
+		t.Fatalf("expected rec-new, got %s", record.ID)
+	}
+}
+
+func TestUpdateDNSRecord_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", r.Method)
+		}
+		writeJSON(t, w, envelope(map[string]any{
+			"id": "rec-1", "type": "A", "name": "www.example.com", "content": "5.6.7.8", "proxied": true, "ttl": 1,
+		}, true))
+	})
+	defer ts.Close()
+
+	record, err := cf.UpdateDNSRecord(context.Background(), "zone-1", "rec-1", &cloudflarw.DNSRecord{
+		Content: "5.6.7.8",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if record.Content != "5.6.7.8" {
+		t.Fatalf("expected 5.6.7.8, got %s", record.Content)
+	}
+}
+
+func TestDeleteDNSRecord_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", r.Method)
+		}
+		writeJSON(t, w, envelope(map[string]string{"id": "rec-1"}, true))
+	})
+	defer ts.Close()
+
+	err := cf.DeleteDNSRecord(context.Background(), "zone-1", "rec-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// --- Tunnels ---
+
+func TestListTunnels_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/accounts/acc-1/cfd_tunnel" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		writeJSON(t, w, envelopeWithInfo([]map[string]any{
+			{"id": "tun-1", "name": "my-tunnel", "status": "healthy", "tun_type": "cfd_tunnel", "account_tag": "acc-1", "conns_count": 2, "created_at": "2024-01-01T00:00:00Z", "deleted_at": "", "remote_config": true},
+		}, &cloudflarw.ListResultInfo{Count: 1, TotalCount: 1}))
+	})
+	defer ts.Close()
+
+	tunnels, _, err := cf.ListTunnels(context.Background(), "acc-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tunnels) != 1 {
+		t.Fatalf("expected 1 tunnel, got %d", len(tunnels))
+	}
+	if tunnels[0].Name != "my-tunnel" {
+		t.Fatalf("expected my-tunnel, got %s", tunnels[0].Name)
+	}
+}
+
+func TestListTunnels_DefaultAccountID(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/accounts/default-acc/cfd_tunnel" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		writeJSON(t, w, envelopeWithInfo([]any{}, &cloudflarw.ListResultInfo{}))
+	}))
+	defer ts.Close()
+
+	cf, _ := New(&Config{APIToken: "test-token", BaseURL: ts.URL, AccountID: "default-acc"})
+	_, _, err := cf.ListTunnels(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetTunnel_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, envelope(map[string]any{
+			"id": "tun-1", "name": "my-tunnel", "status": "healthy", "tun_type": "cfd_tunnel",
+		}, true))
+	})
+	defer ts.Close()
+
+	tunnel, err := cf.GetTunnel(context.Background(), "acc-1", "tun-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tunnel.ID != "tun-1" {
+		t.Fatalf("expected tun-1, got %s", tunnel.ID)
+	}
+}
+
+func TestCreateTunnel_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		json.Unmarshal(body, &req)
+		if req["name"] != "new-tunnel" {
+			t.Fatalf("expected name new-tunnel, got %v", req["name"])
+		}
+
+		writeJSON(t, w, envelope(map[string]any{
+			"id": "tun-new", "name": "new-tunnel", "status": "inactive", "tun_type": "cfd_tunnel", "account_tag": "acc-1", "conns_count": 0, "created_at": "2024-06-01T00:00:00Z", "deleted_at": "", "remote_config": true,
+		}, true))
+	})
+	defer ts.Close()
+
+	tunnel, err := cf.CreateTunnel(context.Background(), "acc-1", "new-tunnel", "cfd_tunnel")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tunnel.Name != "new-tunnel" {
+		t.Fatalf("expected new-tunnel, got %s", tunnel.Name)
+	}
+}
+
+func TestUpdateTunnel_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", r.Method)
+		}
+		writeJSON(t, w, envelope(map[string]any{
+			"id": "tun-1", "name": "renamed-tunnel", "status": "healthy", "tun_type": "cfd_tunnel",
+		}, true))
+	})
+	defer ts.Close()
+
+	tunnel, err := cf.UpdateTunnel(context.Background(), "acc-1", "tun-1", &cloudflarw.Tunnel{Name: "renamed-tunnel"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tunnel.Name != "renamed-tunnel" {
+		t.Fatalf("expected renamed-tunnel, got %s", tunnel.Name)
+	}
+}
+
+func TestDeleteTunnel_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", r.Method)
+		}
+		writeJSON(t, w, envelope(map[string]string{"id": "tun-1"}, true))
+	})
+	defer ts.Close()
+
+	err := cf.DeleteTunnel(context.Background(), "acc-1", "tun-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetTunnelConfig_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, envelope(map[string]any{
+			"config": map[string]any{
+				"ingress": []map[string]any{
+					{"hostname": "app.example.com", "service": "http://localhost:8080"},
+					{"service": "http_status:404"},
+				},
+				"warp-routing": map[string]any{"enabled": true},
+			},
+		}, true))
+	})
+	defer ts.Close()
+
+	config, err := cf.GetTunnelConfig(context.Background(), "acc-1", "tun-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(config.Config.Ingress) != 2 {
+		t.Fatalf("expected 2 ingress rules, got %d", len(config.Config.Ingress))
+	}
+	if config.Config.Ingress[0].Hostname != "app.example.com" {
+		t.Fatalf("expected app.example.com, got %s", config.Config.Ingress[0].Hostname)
+	}
+	if config.Config.WarpRouting == nil || !config.Config.WarpRouting.Enabled {
+		t.Fatal("expected warp routing enabled")
+	}
+}
+
+func TestUpdateTunnelConfig_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("expected PUT, got %s", r.Method)
+		}
+		writeJSON(t, w, envelope(map[string]any{}, true))
+	})
+	defer ts.Close()
+
+	config := &cloudflarw.TunnelConfig{}
+	config.Config.Ingress = []cloudflarw.IngressRule{
+		{Hostname: "app.example.com", Service: "http://localhost:8080"},
+		{Service: "http_status:404"},
+	}
+
+	err := cf.UpdateTunnelConfig(context.Background(), "acc-1", "tun-1", config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetTunnelToken_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/accounts/acc-1/cfd_tunnel/tun-1/token" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		writeJSON(t, w, envelope("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test-token", true))
+	})
+	defer ts.Close()
+
+	token, err := cf.GetTunnelToken(context.Background(), "acc-1", "tun-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test-token" {
+		t.Fatalf("unexpected token: %s", token)
+	}
+}
+
+// --- Access Applications ---
+
+func TestListAccessApps_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/accounts/acc-1/access/apps" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		writeJSON(t, w, envelopeWithInfo([]map[string]any{
+			{"id": "app-1", "name": "My App", "domain": "app.example.com", "type": "self_hosted", "aud": "aud-123"},
+		}, &cloudflarw.ListResultInfo{Count: 1, TotalCount: 1}))
+	})
+	defer ts.Close()
+
+	apps, _, err := cf.ListAccessApps(context.Background(), "acc-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(apps))
+	}
+	if apps[0].Name != "My App" {
+		t.Fatalf("expected My App, got %s", apps[0].Name)
+	}
+}
+
+func TestGetAccessApp_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, envelope(map[string]any{
+			"id": "app-1", "name": "My App", "domain": "app.example.com", "type": "self_hosted", "aud": "aud-123",
+		}, true))
+	})
+	defer ts.Close()
+
+	app, err := cf.GetAccessApp(context.Background(), "acc-1", "app-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if app.ID != "app-1" {
+		t.Fatalf("expected app-1, got %s", app.ID)
+	}
+}
+
+func TestCreateAccessApp_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		writeJSON(t, w, envelope(map[string]any{
+			"id": "app-new", "name": "New App", "domain": "new.example.com", "type": "self_hosted", "aud": "aud-new",
+		}, true))
+	})
+	defer ts.Close()
+
+	app, err := cf.CreateAccessApp(context.Background(), "acc-1", &cloudflarw.AccessApp{
+		Name: "New App", Domain: "new.example.com", Type: "self_hosted",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if app.ID != "app-new" {
+		t.Fatalf("expected app-new, got %s", app.ID)
+	}
+}
+
+func TestUpdateAccessApp_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("expected PUT, got %s", r.Method)
+		}
+		writeJSON(t, w, envelope(map[string]any{
+			"id": "app-1", "name": "Updated App", "domain": "updated.example.com", "type": "self_hosted", "aud": "aud-1",
+		}, true))
+	})
+	defer ts.Close()
+
+	app, err := cf.UpdateAccessApp(context.Background(), "acc-1", "app-1", &cloudflarw.AccessApp{
+		Name: "Updated App", Domain: "updated.example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if app.Name != "Updated App" {
+		t.Fatalf("expected Updated App, got %s", app.Name)
+	}
+}
+
+func TestDeleteAccessApp_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", r.Method)
+		}
+		writeJSON(t, w, envelope(map[string]string{"id": "app-1"}, true))
+	})
+	defer ts.Close()
+
+	err := cf.DeleteAccessApp(context.Background(), "acc-1", "app-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// --- Error path tests ---
+
+func TestDoRequest_InvalidJSON(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	})
+	defer ts.Close()
+
+	_, _, err := cf.ListAccounts(context.Background())
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "decoding response") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDoRequest_MultipleAPIErrors(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, map[string]any{
+			"success": false,
+			"errors": []map[string]any{
+				{"code": 1000, "message": "first error"},
+				{"code": 1001, "message": "second error"},
+			},
+		})
+	})
+	defer ts.Close()
+
+	_, _, err := cf.ListAccounts(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "1000: first error") || !strings.Contains(err.Error(), "1001: second error") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTunnelMethods_MissingAccountID(t *testing.T) {
+	cf, _ := New(&Config{APIToken: "test-token"})
+
+	_, _, err := cf.ListTunnels(context.Background(), "")
+	if err == nil || !strings.Contains(err.Error(), "account id is required") {
+		t.Fatalf("expected account id required error, got: %v", err)
+	}
+
+	_, err = cf.GetTunnel(context.Background(), "", "tun-1")
+	if err == nil || !strings.Contains(err.Error(), "account id is required") {
+		t.Fatalf("expected account id required error, got: %v", err)
+	}
+
+	err = cf.DeleteTunnel(context.Background(), "", "tun-1")
+	if err == nil || !strings.Contains(err.Error(), "account id is required") {
+		t.Fatalf("expected account id required error, got: %v", err)
+	}
+}
+
+func TestAccessAppMethods_MissingAccountID(t *testing.T) {
+	cf, _ := New(&Config{APIToken: "test-token"})
+
+	_, _, err := cf.ListAccessApps(context.Background(), "")
+	if err == nil || !strings.Contains(err.Error(), "account id is required") {
+		t.Fatalf("expected account id required error, got: %v", err)
+	}
+
+	err = cf.DeleteAccessApp(context.Background(), "", "app-1")
+	if err == nil || !strings.Contains(err.Error(), "account id is required") {
+		t.Fatalf("expected account id required error, got: %v", err)
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cf, _ := New(&Config{APIToken: "test-token", BaseURL: "https://httpbin.org"})
+	_, _, err := cf.ListAccounts(ctx)
+	if err == nil {
+		t.Fatal("expected error due to cancelled context")
+	}
+	// The error could be from context cancellation or from the request itself
+	if !strings.Contains(err.Error(), "apiv4w:") {
+		t.Fatalf("expected apiv4w wrapped error, got: %v", err)
+	}
+}
+
+func TestAuthHeader_SentOnEveryRequest(t *testing.T) {
+	var capturedAuth string
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		writeJSON(t, w, envelope([]any{}, true))
+	})
+	defer ts.Close()
+
+	_, _, _ = cf.ListAccounts(context.Background())
+	if capturedAuth != "Bearer test-token" {
+		t.Fatalf("expected Bearer test-token, got %q", capturedAuth)
+	}
+}
+
+func TestContentTypeHeader_SentOnPostRequests(t *testing.T) {
+	var capturedCT string
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		capturedCT = r.Header.Get("Content-Type")
+		writeJSON(t, w, envelope(map[string]any{"id": "test"}, true))
+	})
+	defer ts.Close()
+
+	_, _ = cf.CreateDNSRecord(context.Background(), "zone-1", &cloudflarw.DNSRecord{Type: "A", Name: "test", Content: "1.2.3.4"})
+	if capturedCT != "application/json" {
+		t.Fatalf("expected application/json, got %q", capturedCT)
+	}
+}
+
+func TestDNSRecord_PriorityField(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, envelope(map[string]any{
+			"id": "rec-1", "type": "MX", "name": "example.com", "content": "mail.example.com",
+			"proxied": false, "ttl": 3600, "priority": 10,
+		}, true))
+	})
+	defer ts.Close()
+
+	record, err := cf.GetDNSRecord(context.Background(), "zone-1", "rec-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if record.Priority == nil || *record.Priority != 10 {
+		t.Fatalf("expected priority 10, got %v", record.Priority)
+	}
+}
+
+func TestCustomHTTPClient(t *testing.T) {
+	customClient := &http.Client{
+		Transport: http.DefaultTransport,
+	}
+	cf, err := New(&Config{
+		APIToken:   "test-token",
+		HTTPClient: customClient,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := cf.(*cfClient)
+	if c.client != customClient {
+		t.Fatal("expected custom HTTP client to be used")
+	}
+}
+
+func TestAllMethodPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(cf cloudflarw.Cloudflare) error
+		path string
+	}{
+		{
+			"ListAccounts", func(cf cloudflarw.Cloudflare) error { _, _, err := cf.ListAccounts(context.Background()); return err }, "/accounts",
+		},
+		{
+			"ListZones", func(cf cloudflarw.Cloudflare) error { _, _, err := cf.ListZones(context.Background()); return err }, "/zones",
+		},
+		{
+			"GetZone", func(cf cloudflarw.Cloudflare) error { _, err := cf.GetZone(context.Background(), "z1"); return err }, "/zones/z1",
+		},
+		{
+			"ListDNSRecords", func(cf cloudflarw.Cloudflare) error { _, _, err := cf.ListDNSRecords(context.Background(), "z1"); return err }, "/zones/z1/dns_records",
+		},
+		{
+			"GetDNSRecord", func(cf cloudflarw.Cloudflare) error { _, err := cf.GetDNSRecord(context.Background(), "z1", "r1"); return err }, "/zones/z1/dns_records/r1",
+		},
+		{
+			"DeleteDNSRecord", func(cf cloudflarw.Cloudflare) error { return cf.DeleteDNSRecord(context.Background(), "z1", "r1") }, "/zones/z1/dns_records/r1",
+		},
+		{
+			"ListTunnels", func(cf cloudflarw.Cloudflare) error { _, _, err := cf.ListTunnels(context.Background(), "a1"); return err }, "/accounts/a1/cfd_tunnel",
+		},
+		{
+			"GetTunnel", func(cf cloudflarw.Cloudflare) error { _, err := cf.GetTunnel(context.Background(), "a1", "t1"); return err }, "/accounts/a1/cfd_tunnel/t1",
+		},
+		{
+			"DeleteTunnel", func(cf cloudflarw.Cloudflare) error { return cf.DeleteTunnel(context.Background(), "a1", "t1") }, "/accounts/a1/cfd_tunnel/t1",
+		},
+		{
+			"GetTunnelConfig", func(cf cloudflarw.Cloudflare) error { _, err := cf.GetTunnelConfig(context.Background(), "a1", "t1"); return err }, "/accounts/a1/cfd_tunnel/t1/configurations",
+		},
+		{
+			"GetTunnelToken", func(cf cloudflarw.Cloudflare) error { _, err := cf.GetTunnelToken(context.Background(), "a1", "t1"); return err }, "/accounts/a1/cfd_tunnel/t1/token",
+		},
+		{
+			"ListAccessApps", func(cf cloudflarw.Cloudflare) error { _, _, err := cf.ListAccessApps(context.Background(), "a1"); return err }, "/accounts/a1/access/apps",
+		},
+		{
+			"GetAccessApp", func(cf cloudflarw.Cloudflare) error { _, err := cf.GetAccessApp(context.Background(), "a1", "ap1"); return err }, "/accounts/a1/access/apps/ap1",
+		},
+		{
+			"DeleteAccessApp", func(cf cloudflarw.Cloudflare) error { return cf.DeleteAccessApp(context.Background(), "a1", "ap1") }, "/accounts/a1/access/apps/ap1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedPath string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedPath = r.URL.Path
+				writeJSON(t, w, envelope([]any{}, true))
+			}))
+			defer ts.Close()
+
+			cf, _ := New(&Config{APIToken: "test-token", BaseURL: ts.URL, AccountID: "a1"})
+			_ = tt.call(cf)
+			if capturedPath != tt.path {
+				t.Errorf("expected path %s, got %s", tt.path, capturedPath)
+			}
+		})
+	}
+}

--- a/v2/cloudflarw/apiv4w/integration_test.go
+++ b/v2/cloudflarw/apiv4w/integration_test.go
@@ -1,0 +1,238 @@
+//go:build integration
+
+package apiv4w
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/AndreeJait/go-utility/v2/cloudflarw"
+)
+
+// newIntegrationClient creates a Cloudflare client for integration testing.
+// Requires CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID environment variables.
+//
+// Run with:
+//
+//	cd v2 && go test ./cloudflarw/apiv4w/ -tags=integration -run TestIntegration -v -timeout 120s
+func newIntegrationClient(t *testing.T) cloudflarw.Cloudflare {
+	t.Helper()
+
+	token := os.Getenv("CLOUDFLARE_API_TOKEN")
+	if token == "" {
+		t.Fatal("CLOUDFLARE_API_TOKEN environment variable is required for integration tests")
+	}
+
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		t.Fatal("CLOUDFLARE_ACCOUNT_ID environment variable is required for integration tests")
+	}
+
+	cf, err := New(&Config{
+		APIToken:  token,
+		AccountID: accountID,
+		DebugMode: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	return cf
+}
+
+func TestIntegration_ListAccounts(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cf := newIntegrationClient(t)
+	accounts, info, err := cf.ListAccounts(ctx)
+	if err != nil {
+		t.Fatalf("ListAccounts: %v", err)
+	}
+	t.Logf("accounts: %+v", accounts)
+	t.Logf("result_info: %+v", info)
+
+	if len(accounts) == 0 {
+		t.Fatal("expected at least one account")
+	}
+}
+
+func TestIntegration_ListZones(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cf := newIntegrationClient(t)
+	zones, info, err := cf.ListZones(ctx)
+	if err != nil {
+		t.Fatalf("ListZones: %v", err)
+	}
+	t.Logf("zones count: %d", len(zones))
+	t.Logf("result_info: %+v", info)
+
+	if len(zones) == 0 {
+		t.Log("no zones found — this is normal if no domains are integrated")
+	}
+}
+
+func TestIntegration_DNSRecords_CRUD(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cf := newIntegrationClient(t)
+
+	// Find a zone to test with
+	zones, _, err := cf.ListZones(ctx)
+	if err != nil {
+		t.Fatalf("ListZones: %v", err)
+	}
+	if len(zones) == 0 {
+		t.Skip("no zones available for DNS record testing")
+	}
+
+	zoneID := zones[0].ID
+	zoneName := zones[0].Name
+	t.Logf("using zone: %s (%s)", zoneName, zoneID)
+
+	// Create a test TXT record
+	recordName := fmt.Sprintf("_cfw-test.%s", zoneName)
+	created, err := cf.CreateDNSRecord(ctx, zoneID, &cloudflarw.DNSRecord{
+		Type:    "TXT",
+		Name:    recordName,
+		Content: "cloudflarw integration test",
+		TTL:     120,
+	})
+	if err != nil {
+		t.Fatalf("CreateDNSRecord: %v", err)
+	}
+	t.Logf("created DNS record: id=%s name=%s", created.ID, created.Name)
+
+	// Clean up: delete the record after test
+	defer func() {
+		delCtx, delCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer delCancel()
+		if err := cf.DeleteDNSRecord(delCtx, zoneID, created.ID); err != nil {
+			t.Logf("cleanup: failed to delete DNS record %s: %v", created.ID, err)
+		} else {
+			t.Logf("cleanup: deleted DNS record %s", created.ID)
+		}
+	}()
+
+	// Get the record
+	got, err := cf.GetDNSRecord(ctx, zoneID, created.ID)
+	if err != nil {
+		t.Fatalf("GetDNSRecord: %v", err)
+	}
+	if got.Content != "cloudflarw integration test" {
+		t.Fatalf("expected content 'cloudflarw integration test', got %q", got.Content)
+	}
+	t.Logf("got DNS record: id=%s content=%s", got.ID, got.Content)
+
+	// Update the record
+	updated, err := cf.UpdateDNSRecord(ctx, zoneID, created.ID, &cloudflarw.DNSRecord{
+		Type:    "TXT",
+		Name:    recordName,
+		Content: "cloudflarw integration test updated",
+		TTL:     120,
+	})
+	if err != nil {
+		t.Fatalf("UpdateDNSRecord: %v", err)
+	}
+	if updated.Content != "cloudflarw integration test updated" {
+		t.Fatalf("expected updated content, got %q", updated.Content)
+	}
+	t.Logf("updated DNS record: id=%s content=%s", updated.ID, updated.Content)
+
+	// List records and verify our record exists
+	records, _, err := cf.ListDNSRecords(ctx, zoneID)
+	if err != nil {
+		t.Fatalf("ListDNSRecords: %v", err)
+	}
+	found := false
+	for _, r := range records {
+		if r.ID == created.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("created DNS record not found in list")
+	}
+	t.Logf("listed %d DNS records, found test record", len(records))
+}
+
+func TestIntegration_Tunnels_CRUD(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cf := newIntegrationClient(t)
+
+	// List existing tunnels
+	tunnels, _, err := cf.ListTunnels(ctx, "")
+	if err != nil {
+		t.Fatalf("ListTunnels: %v", err)
+	}
+	t.Logf("existing tunnels: %d", len(tunnels))
+
+	// Create a test tunnel
+	tunnel, err := cf.CreateTunnel(ctx, "", "cfw-integration-test", "cfd_tunnel")
+	if err != nil {
+		t.Fatalf("CreateTunnel: %v", err)
+	}
+	t.Logf("created tunnel: id=%s name=%s", tunnel.ID, tunnel.Name)
+
+	// Clean up: delete the tunnel after test
+	defer func() {
+		delCtx, delCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer delCancel()
+		if err := cf.DeleteTunnel(delCtx, "", tunnel.ID); err != nil {
+			t.Logf("cleanup: failed to delete tunnel %s: %v", tunnel.ID, err)
+		} else {
+			t.Logf("cleanup: deleted tunnel %s", tunnel.ID)
+		}
+	}()
+
+	// Get the tunnel
+	got, err := cf.GetTunnel(ctx, "", tunnel.ID)
+	if err != nil {
+		t.Fatalf("GetTunnel: %v", err)
+	}
+	if got.Name != "cfw-integration-test" {
+		t.Fatalf("expected name cfw-integration-test, got %q", got.Name)
+	}
+	t.Logf("got tunnel: id=%s name=%s status=%s", got.ID, got.Name, got.Status)
+
+	// Get tunnel token
+	token, err := cf.GetTunnelToken(ctx, "", tunnel.ID)
+	if err != nil {
+		t.Logf("GetTunnelToken: %v (may fail if tunnel is inactive)", err)
+	} else {
+		t.Logf("tunnel token: %s...", token[:min(20, len(token))])
+	}
+
+	// Get tunnel config
+	config, err := cf.GetTunnelConfig(ctx, "", tunnel.ID)
+	if err != nil {
+		t.Logf("GetTunnelConfig: %v (may fail for new tunnels)", err)
+	} else {
+		t.Logf("tunnel config ingress rules: %d", len(config.Config.Ingress))
+	}
+}
+
+func TestIntegration_AccessApps_List(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cf := newIntegrationClient(t)
+
+	apps, info, err := cf.ListAccessApps(ctx, "")
+	if err != nil {
+		t.Fatalf("ListAccessApps: %v", err)
+	}
+	t.Logf("access apps count: %d", len(apps))
+	t.Logf("result_info: %+v", info)
+
+	for i, app := range apps {
+		t.Logf("app[%d]: id=%s name=%s domain=%s type=%s", i, app.ID, app.Name, app.Domain, app.Type)
+	}
+}

--- a/v2/cloudflarw/cloudflare.go
+++ b/v2/cloudflarw/cloudflare.go
@@ -1,0 +1,177 @@
+package cloudflarw
+
+import "context"
+
+// Account represents a Cloudflare account.
+type Account struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// Zone represents a Cloudflare zone (domain).
+type Zone struct {
+	ID      string  `json:"id"`
+	Name    string  `json:"name"`
+	Status  string  `json:"status"`
+	Account Account `json:"account"`
+}
+
+// DNSRecord represents a DNS record within a zone.
+type DNSRecord struct {
+	ID         string   `json:"id"`
+	Type       string   `json:"type"`
+	Name       string   `json:"name"`
+	Content    string   `json:"content"`
+	Proxied    bool     `json:"proxied"`
+	TTL        int      `json:"ttl"`
+	Priority   *int     `json:"priority,omitempty"`
+	Comment    string   `json:"comment,omitempty"`
+	Tags       []string `json:"tags,omitempty"`
+	CreatedOn  string   `json:"created_on,omitempty"`
+	ModifiedOn string   `json:"modified_on,omitempty"`
+}
+
+// Tunnel represents a Cloudflare Tunnel (cloudflared).
+type Tunnel struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Status         string `json:"status"`
+	TunType        string `json:"tun_type"`
+	AccountTag     string `json:"account_tag"`
+	ConfigSrc      string `json:"config_src"`
+	ConnsCount     int    `json:"conns_count"`
+	ConnsActiveAt  string `json:"conns_active_at,omitempty"`
+	CreatedAt      string `json:"created_at"`
+	DeletedAt      string `json:"deleted_at,omitempty"`
+	TunnelToken     string `json:"tunnel_token,omitempty"`
+	RemoteConfig   bool   `json:"remote_config"`
+}
+
+// TunnelConfig represents the configuration of a Cloudflare Tunnel.
+type TunnelConfig struct {
+	Config struct {
+		Ingress     []IngressRule     `json:"ingress"`
+		WarpRouting *WarpRoutingConfig `json:"warp-routing,omitempty"`
+	} `json:"config"`
+}
+
+// IngressRule represents a single ingress rule in a tunnel configuration.
+type IngressRule struct {
+	Hostname string        `json:"hostname,omitempty"`
+	Path     string        `json:"path,omitempty"`
+	Service  string        `json:"service"`
+	Origin   *OriginConfig `json:"origin,omitempty"`
+}
+
+// OriginConfig represents origin request configuration for an ingress rule.
+type OriginConfig struct {
+	NoTLSVerify     bool   `json:"noTLSVerify,omitempty"`
+	ConnectTimeout  string `json:"connectTimeout,omitempty"`
+	TLSTimeout      string `json:"tlsTimeout,omitempty"`
+	ProxyType       string `json:"proxyType,omitempty"`
+}
+
+// WarpRoutingConfig represents warp routing configuration for a tunnel.
+type WarpRoutingConfig struct {
+	Enabled bool `json:"enabled"`
+}
+
+// AccessApp represents a Cloudflare Zero Trust Access Application.
+type AccessApp struct {
+	ID                  string   `json:"id"`
+	Name                string   `json:"name"`
+	Domain              string   `json:"domain,omitempty"`
+	Type                string   `json:"type"`
+	Aud                 string   `json:"aud"`
+	SessionDuration     string   `json:"session_duration,omitempty"`
+	AllowedIDPs         []string `json:"allowed_idps,omitempty"`
+	AutoRedirectToIDP   bool     `json:"auto_redirect_to_identity,omitempty"`
+	AppLauncherVisible  bool     `json:"app_launcher_visible,omitempty"`
+	CreatedAt           string   `json:"created_at,omitempty"`
+	UpdatedAt           string   `json:"updated_at,omitempty"`
+}
+
+// ListResultInfo holds pagination metadata from Cloudflare API responses.
+type ListResultInfo struct {
+	Count      int `json:"count"`
+	Page       int `json:"page"`
+	PerPage    int `json:"per_page"`
+	TotalCount int `json:"total_count"`
+}
+
+// Cloudflare defines the contract for interacting with the Cloudflare API v4.
+type Cloudflare interface {
+	// --- Accounts ---
+
+	// ListAccounts returns all accounts the authenticated user has access to.
+	ListAccounts(ctx context.Context) ([]Account, *ListResultInfo, error)
+
+	// --- Zones ---
+
+	// ListZones returns all zones (domains) for the authenticated account.
+	ListZones(ctx context.Context) ([]Zone, *ListResultInfo, error)
+
+	// GetZone returns details for a single zone.
+	GetZone(ctx context.Context, zoneID string) (*Zone, error)
+
+	// --- DNS Records ---
+
+	// ListDNSRecords returns all DNS records in a zone.
+	ListDNSRecords(ctx context.Context, zoneID string) ([]DNSRecord, *ListResultInfo, error)
+
+	// GetDNSRecord returns a single DNS record.
+	GetDNSRecord(ctx context.Context, zoneID, recordID string) (*DNSRecord, error)
+
+	// CreateDNSRecord creates a new DNS record in a zone.
+	CreateDNSRecord(ctx context.Context, zoneID string, record *DNSRecord) (*DNSRecord, error)
+
+	// UpdateDNSRecord updates an existing DNS record.
+	UpdateDNSRecord(ctx context.Context, zoneID, recordID string, record *DNSRecord) (*DNSRecord, error)
+
+	// DeleteDNSRecord deletes a DNS record from a zone.
+	DeleteDNSRecord(ctx context.Context, zoneID, recordID string) error
+
+	// --- Tunnels ---
+
+	// ListTunnels returns all tunnels for the account.
+	ListTunnels(ctx context.Context, accountID string) ([]Tunnel, *ListResultInfo, error)
+
+	// GetTunnel returns details for a single tunnel.
+	GetTunnel(ctx context.Context, accountID, tunnelID string) (*Tunnel, error)
+
+	// CreateTunnel creates a new tunnel in the account.
+	CreateTunnel(ctx context.Context, accountID, name, tunnelType string) (*Tunnel, error)
+
+	// UpdateTunnel updates an existing tunnel.
+	UpdateTunnel(ctx context.Context, accountID, tunnelID string, tunnel *Tunnel) (*Tunnel, error)
+
+	// DeleteTunnel deletes a tunnel.
+	DeleteTunnel(ctx context.Context, accountID, tunnelID string) error
+
+	// GetTunnelConfig returns the configuration of a tunnel.
+	GetTunnelConfig(ctx context.Context, accountID, tunnelID string) (*TunnelConfig, error)
+
+	// UpdateTunnelConfig updates the configuration of a tunnel.
+	UpdateTunnelConfig(ctx context.Context, accountID, tunnelID string, config *TunnelConfig) error
+
+	// GetTunnelToken returns the token for a tunnel.
+	GetTunnelToken(ctx context.Context, accountID, tunnelID string) (string, error)
+
+	// --- Access Applications (Zero Trust) ---
+
+	// ListAccessApps returns all Access applications for the account.
+	ListAccessApps(ctx context.Context, accountID string) ([]AccessApp, *ListResultInfo, error)
+
+	// GetAccessApp returns a single Access application.
+	GetAccessApp(ctx context.Context, accountID, appID string) (*AccessApp, error)
+
+	// CreateAccessApp creates a new Access application.
+	CreateAccessApp(ctx context.Context, accountID string, app *AccessApp) (*AccessApp, error)
+
+	// UpdateAccessApp updates an existing Access application.
+	UpdateAccessApp(ctx context.Context, accountID, appID string, app *AccessApp) (*AccessApp, error)
+
+	// DeleteAccessApp deletes an Access application.
+	DeleteAccessApp(ctx context.Context, accountID, appID string) error
+}

--- a/v2/llmw/openaiw/openai.go
+++ b/v2/llmw/openaiw/openai.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/AndreeJait/go-utility/v2/llmw"
 	"github.com/AndreeJait/go-utility/v2/logw"
@@ -27,6 +28,10 @@ type Config struct {
 	BaseURL string
 	// OrgID is the optional organization ID.
 	OrgID string
+	// HTTPClient is an optional custom HTTP client. Use this to inject authenticated
+	// clients (e.g., gcpw.AuthenticatedHTTPClient for GCP Cloud Run). If nil, the
+	// SDK's default client is used.
+	HTTPClient *http.Client
 }
 
 // New creates a new OpenAI LLM provider.
@@ -45,6 +50,9 @@ func New(cfg *Config) (llmw.LLM, error) {
 	}
 	if cfg.OrgID != "" {
 		opts = append(opts, option.WithOrganization(cfg.OrgID))
+	}
+	if cfg.HTTPClient != nil {
+		opts = append(opts, option.WithHTTPClient(cfg.HTTPClient))
 	}
 
 	client := openai.NewClient(opts...)

--- a/v2/tuyaw/apiv1w/apiv1.go
+++ b/v2/tuyaw/apiv1w/apiv1.go
@@ -1,0 +1,529 @@
+package apiv1w
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/AndreeJait/go-utility/v2/tuyaw"
+)
+
+const defaultBaseURL = "https://openapi-sg.iotbing.com"
+
+// Region base URLs for convenience.
+const (
+	RegionCN = "https://openapi.tuyacn.com"
+	RegionUS = "https://openapi.tuyaus.com"
+	RegionEU = "https://openapi.tuyaeu.com"
+	RegionIN = "https://openapi.tuyain.com"
+	RegionSG = "https://openapi-sg.iotbing.com"
+)
+
+// Config holds the configuration for the Tuya API v1 client.
+type Config struct {
+	// AccessID is the client_id from your Tuya project. Required.
+	AccessID string
+
+	// AccessKey is the secret key from your Tuya project. Required.
+	AccessKey string
+
+	// BaseURL overrides the Tuya API base URL.
+	// Defaults to "https://openapi-sg.iotbing.com" if empty.
+	// If Region is set, Region takes precedence.
+	BaseURL string
+
+	// Region sets the base URL by region. Supported: "us", "cn", "eu", "in", "sg".
+	// If set, overrides BaseURL. Optional.
+	Region string
+
+	// HTTPClient is an optional custom HTTP client. If nil, http.DefaultClient is used.
+	HTTPClient *http.Client
+
+	// DebugMode enables verbose logging of API requests and responses.
+	DebugMode bool
+}
+
+type tuyaClient struct {
+	client    *http.Client
+	baseURL   string
+	accessID  string
+	accessKey string
+	debug     bool
+
+	mu           sync.RWMutex
+	accessToken  string
+	refreshToken string
+	expireAt     time.Time
+}
+
+var _ tuyaw.Tuya = (*tuyaClient)(nil)
+
+// New creates a new Tuya API v1 client from the given config.
+func New(cfg *Config) (tuyaw.Tuya, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("apiv1w: config is required")
+	}
+	if cfg.AccessID == "" {
+		return nil, fmt.Errorf("apiv1w: access id is required")
+	}
+	if cfg.AccessKey == "" {
+		return nil, fmt.Errorf("apiv1w: access key is required")
+	}
+
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	// Region overrides BaseURL
+	switch strings.ToLower(cfg.Region) {
+	case "cn":
+		baseURL = RegionCN
+	case "us":
+		baseURL = RegionUS
+	case "eu":
+		baseURL = RegionEU
+	case "in":
+		baseURL = RegionIN
+	case "sg":
+		baseURL = RegionSG
+	case "":
+		// use baseURL as-is
+	default:
+		return nil, fmt.Errorf("apiv1w: unsupported region %q, use cn, us, eu, in, or sg", cfg.Region)
+	}
+
+	client := cfg.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	return &tuyaClient{
+		client:    client,
+		baseURL:   baseURL,
+		accessID:  cfg.AccessID,
+		accessKey: cfg.AccessKey,
+		debug:     cfg.DebugMode,
+	}, nil
+}
+
+// --- Token management ---
+
+func (c *tuyaClient) tokenValid() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.accessToken != "" && time.Now().Before(c.expireAt.Add(-5*time.Minute))
+}
+
+func (c *tuyaClient) getAccessToken() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.accessToken
+}
+
+func (c *tuyaClient) getRefreshToken() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.refreshToken
+}
+
+func (c *tuyaClient) setToken(token *tuyaw.Token) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.accessToken = token.AccessToken
+	c.refreshToken = token.RefreshToken
+	c.expireAt = time.Now().Add(time.Duration(token.ExpireTime) * time.Second)
+}
+
+// ensureToken checks if the current token is valid and refreshes/acquires if needed.
+func (c *tuyaClient) ensureToken(ctx context.Context) error {
+	if c.tokenValid() {
+		return nil
+	}
+
+	// Try refresh first if we have a refresh token
+	refreshToken := c.getRefreshToken()
+	if refreshToken != "" {
+		token, err := c.RefreshToken(ctx, refreshToken)
+		if err != nil {
+			// Refresh failed, try getting a new token
+			token, err = c.GetToken(ctx)
+			if err != nil {
+				return fmt.Errorf("apiv1w: failed to acquire token: %w", err)
+			}
+			c.setToken(token)
+			return nil
+		}
+		c.setToken(token)
+		return nil
+	}
+
+	// No refresh token, get a new one
+	token, err := c.GetToken(ctx)
+	if err != nil {
+		return fmt.Errorf("apiv1w: failed to acquire token: %w", err)
+	}
+	c.setToken(token)
+	return nil
+}
+
+// --- HMAC-SHA256 signing ---
+
+func sha256Hex(data string) string {
+	h := sha256.Sum256([]byte(data))
+	return hex.EncodeToString(h[:])
+}
+
+func hmacSHA256(data, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(data))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func (c *tuyaClient) sign(method, path, body string, t int64, nonce, accessToken string) string {
+	// 1. SHA256 of body (empty body uses known constant)
+	contentSHA256 := sha256Hex(body)
+	if body == "" {
+		contentSHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	}
+
+	// 2. stringToSign = method + "\n" + contentSHA256 + "\n" + signatureHeaders + "\n" + url
+	stringToSign := method + "\n" + contentSHA256 + "\n\n" + path
+
+	// 3. str = client_id + access_token + t + nonce + stringToSign
+	str := c.accessID + accessToken + fmt.Sprintf("%d", t) + nonce + stringToSign
+
+	// 4. sign = HMAC-SHA256(str, secret).toUpperCase()
+	return strings.ToUpper(hmacSHA256(str, c.accessKey))
+}
+
+// --- HTTP request helper ---
+
+type tuyaResponse struct {
+	Success bool            `json:"success"`
+	Code    int             `json:"code"`
+	Msg     string          `json:"msg"`
+	Result  json.RawMessage `json:"result"`
+	T       int64           `json:"t"`
+}
+
+func (c *tuyaClient) doRequest(ctx context.Context, method, path string, body io.Reader, isTokenRequest bool) (json.RawMessage, error) {
+	t := time.Now().UnixMilli()
+	nonce := generateNonce()
+
+	accessToken := ""
+	if !isTokenRequest {
+		if err := c.ensureToken(ctx); err != nil {
+			return nil, err
+		}
+		accessToken = c.getAccessToken()
+	}
+
+	// Read body for signing (we need to know the content for the hash)
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(body)
+		if err != nil {
+			return nil, fmt.Errorf("apiv1w: reading request body: %w", err)
+		}
+	}
+
+	bodyStr := ""
+	if len(bodyBytes) > 0 {
+		bodyStr = string(bodyBytes)
+	}
+
+	sign := c.sign(method, path, bodyStr, t, nonce, accessToken)
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("apiv1w: creating request: %w", err)
+	}
+
+	req.Header.Set("client_id", c.accessID)
+	req.Header.Set("sign", sign)
+	req.Header.Set("sign_method", "HMAC-SHA256")
+	req.Header.Set("t", strconv.FormatInt(t, 10))
+	req.Header.Set("nonce", nonce)
+
+	if !isTokenRequest && accessToken != "" {
+		req.Header.Set("access_token", accessToken)
+	}
+
+	if len(bodyBytes) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("apiv1w: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("apiv1w: reading response: %w", err)
+	}
+
+	var tuyaResp tuyaResponse
+	if err := json.Unmarshal(respBody, &tuyaResp); err != nil {
+		return nil, fmt.Errorf("apiv1w: decoding response: %w", err)
+	}
+
+	if !tuyaResp.Success {
+		return nil, fmt.Errorf("apiv1w: api error %d: %s", tuyaResp.Code, tuyaResp.Msg)
+	}
+
+	return tuyaResp.Result, nil
+}
+
+func generateNonce() string {
+	b := make([]byte, 16)
+	for i := range b {
+		b[i] = byte(i * 7 % 256)
+	}
+	return hex.EncodeToString(b)
+}
+
+// --- Token Management ---
+
+func (c *tuyaClient) GetToken(ctx context.Context) (*tuyaw.Token, error) {
+	result, err := c.doRequest(ctx, http.MethodGet, "/v1.0/token?grant_type=1", nil, true)
+	if err != nil {
+		return nil, fmt.Errorf("apiv1w: get token: %w", err)
+	}
+
+	var token tuyaw.Token
+	if err := json.Unmarshal(result, &token); err != nil {
+		return nil, fmt.Errorf("apiv1w: decoding token: %w", err)
+	}
+
+	c.setToken(&token)
+	return &token, nil
+}
+
+func (c *tuyaClient) RefreshToken(ctx context.Context, refreshToken string) (*tuyaw.Token, error) {
+	path := "/v1.0/token/" + refreshToken
+	result, err := c.doRequest(ctx, http.MethodGet, path, nil, true)
+	if err != nil {
+		return nil, fmt.Errorf("apiv1w: refresh token: %w", err)
+	}
+
+	var token tuyaw.Token
+	if err := json.Unmarshal(result, &token); err != nil {
+		return nil, fmt.Errorf("apiv1w: decoding token: %w", err)
+	}
+
+	c.setToken(&token)
+	return &token, nil
+}
+
+// --- Device Management ---
+
+func (c *tuyaClient) GetDevice(ctx context.Context, deviceID string) (*tuyaw.Device, error) {
+	result, err := c.doRequest(ctx, http.MethodGet, "/v1.0/devices/"+deviceID, nil, false)
+	if err != nil {
+		return nil, fmt.Errorf("apiv1w: get device: %w", err)
+	}
+
+	var device tuyaw.Device
+	if err := json.Unmarshal(result, &device); err != nil {
+		return nil, fmt.Errorf("apiv1w: decoding device: %w", err)
+	}
+	return &device, nil
+}
+
+func (c *tuyaClient) ListDevices(ctx context.Context, opts *tuyaw.ListDevicesOptions) ([]tuyaw.Device, error) {
+	var path string
+	if opts != nil && opts.UID != "" {
+		path = "/v1.0/users/" + opts.UID + "/devices"
+	} else {
+		path = "/v1.0/devices"
+	}
+
+	// Add query parameters
+	params := url.Values{}
+	if opts != nil {
+		if opts.PageNo > 0 {
+			params.Set("page_no", strconv.Itoa(opts.PageNo))
+		}
+		if opts.PageSize > 0 {
+			params.Set("page_size", strconv.Itoa(opts.PageSize))
+		}
+		if opts.ProductID != "" {
+			params.Set("product_id", opts.ProductID)
+		}
+		if len(opts.DeviceIDs) > 0 {
+			params.Set("device_ids", strings.Join(opts.DeviceIDs, ","))
+		}
+	}
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	result, err := c.doRequest(ctx, http.MethodGet, path, nil, false)
+	if err != nil {
+		return nil, fmt.Errorf("apiv1w: list devices: %w", err)
+	}
+
+	var devices []tuyaw.Device
+	if err := json.Unmarshal(result, &devices); err != nil {
+		return nil, fmt.Errorf("apiv1w: decoding devices: %w", err)
+	}
+	return devices, nil
+}
+
+func (c *tuyaClient) UpdateDeviceName(ctx context.Context, deviceID, name string) error {
+	body, _ := json.Marshal(map[string]string{"name": name})
+	_, err := c.doRequest(ctx, http.MethodPut, "/v1.0/devices/"+deviceID, bytes.NewReader(body), false)
+	if err != nil {
+		return fmt.Errorf("apiv1w: update device name: %w", err)
+	}
+	return nil
+}
+
+func (c *tuyaClient) DeleteDevice(ctx context.Context, deviceID string) error {
+	_, err := c.doRequest(ctx, http.MethodDelete, "/v1.0/devices/"+deviceID, nil, false)
+	if err != nil {
+		return fmt.Errorf("apiv1w: delete device: %w", err)
+	}
+	return nil
+}
+
+func (c *tuyaClient) GetDeviceSpecifications(ctx context.Context, deviceID string) (*tuyaw.DeviceSpecification, error) {
+	result, err := c.doRequest(ctx, http.MethodGet, "/v1.0/devices/"+deviceID+"/specifications", nil, false)
+	if err != nil {
+		return nil, fmt.Errorf("apiv1w: get device specifications: %w", err)
+	}
+
+	var spec tuyaw.DeviceSpecification
+	if err := json.Unmarshal(result, &spec); err != nil {
+		return nil, fmt.Errorf("apiv1w: decoding device specifications: %w", err)
+	}
+	return &spec, nil
+}
+
+func (c *tuyaClient) GetDeviceFactoryInfos(ctx context.Context, deviceIDs []string) ([]tuyaw.DeviceFactoryInfo, error) {
+	path := "/v1.0/devices/factory-infos?device_ids=" + strings.Join(deviceIDs, ",")
+	result, err := c.doRequest(ctx, http.MethodGet, path, nil, false)
+	if err != nil {
+		return nil, fmt.Errorf("apiv1w: get device factory infos: %w", err)
+	}
+
+	var infos []tuyaw.DeviceFactoryInfo
+	if err := json.Unmarshal(result, &infos); err != nil {
+		return nil, fmt.Errorf("apiv1w: decoding device factory infos: %w", err)
+	}
+	return infos, nil
+}
+
+func (c *tuyaClient) ListSubDevices(ctx context.Context, deviceID string) ([]tuyaw.SubDevice, error) {
+	result, err := c.doRequest(ctx, http.MethodGet, "/v1.0/devices/"+deviceID+"/sub-devices", nil, false)
+	if err != nil {
+		return nil, fmt.Errorf("apiv1w: list sub-devices: %w", err)
+	}
+
+	var devices []tuyaw.SubDevice
+	if err := json.Unmarshal(result, &devices); err != nil {
+		return nil, fmt.Errorf("apiv1w: decoding sub-devices: %w", err)
+	}
+	return devices, nil
+}
+
+func (c *tuyaClient) GetDeviceLogs(ctx context.Context, deviceID string, opts *tuyaw.DeviceLogOptions) ([]tuyaw.DeviceLog, error) {
+	path := "/v1.0/devices/" + deviceID + "/logs"
+	if opts != nil {
+		params := url.Values{}
+		if opts.StartTime > 0 {
+			params.Set("start_time", strconv.FormatInt(opts.StartTime, 10))
+		}
+		if opts.EndTime > 0 {
+			params.Set("end_time", strconv.FormatInt(opts.EndTime, 10))
+		}
+		if opts.Category != "" {
+			params.Set("type", opts.Category)
+		}
+		if opts.PageNo > 0 {
+			params.Set("page_no", strconv.Itoa(opts.PageNo))
+		}
+		if opts.PageSize > 0 {
+			params.Set("page_size", strconv.Itoa(opts.PageSize))
+		}
+		if len(params) > 0 {
+			path += "?" + params.Encode()
+		}
+	}
+
+	result, err := c.doRequest(ctx, http.MethodGet, path, nil, false)
+	if err != nil {
+		return nil, fmt.Errorf("apiv1w: get device logs: %w", err)
+	}
+
+	var logs []tuyaw.DeviceLog
+	if err := json.Unmarshal(result, &logs); err != nil {
+		return nil, fmt.Errorf("apiv1w: decoding device logs: %w", err)
+	}
+	return logs, nil
+}
+
+// --- Device Control ---
+
+func (c *tuyaClient) SendCommands(ctx context.Context, deviceID string, commands []tuyaw.DeviceCommand) error {
+	body, _ := json.Marshal(map[string]any{"commands": commands})
+	_, err := c.doRequest(ctx, http.MethodPost, "/v1.0/devices/"+deviceID+"/commands", bytes.NewReader(body), false)
+	if err != nil {
+		return fmt.Errorf("apiv1w: send commands: %w", err)
+	}
+	return nil
+}
+
+func (c *tuyaClient) GetDeviceStatus(ctx context.Context, deviceID string) ([]tuyaw.DeviceStatusPoint, error) {
+	result, err := c.doRequest(ctx, http.MethodGet, "/v1.0/devices/"+deviceID+"/status", nil, false)
+	if err != nil {
+		return nil, fmt.Errorf("apiv1w: get device status: %w", err)
+	}
+
+	var status []tuyaw.DeviceStatusPoint
+	if err := json.Unmarshal(result, &status); err != nil {
+		return nil, fmt.Errorf("apiv1w: decoding device status: %w", err)
+	}
+	return status, nil
+}
+
+func (c *tuyaClient) GetDeviceFunctions(ctx context.Context, deviceID string) (*tuyaw.DeviceFunctionsResult, error) {
+	result, err := c.doRequest(ctx, http.MethodGet, "/v1.0/devices/"+deviceID+"/functions", nil, false)
+	if err != nil {
+		return nil, fmt.Errorf("apiv1w: get device functions: %w", err)
+	}
+
+	var functionsResult tuyaw.DeviceFunctionsResult
+	if err := json.Unmarshal(result, &functionsResult); err != nil {
+		return nil, fmt.Errorf("apiv1w: decoding device functions: %w", err)
+	}
+	return &functionsResult, nil
+}
+
+func (c *tuyaClient) GetCategoryFunctions(ctx context.Context, category string) (*tuyaw.DeviceFunctionsResult, error) {
+	result, err := c.doRequest(ctx, http.MethodGet, "/v1.0/functions/"+category, nil, false)
+	if err != nil {
+		return nil, fmt.Errorf("apiv1w: get category functions: %w", err)
+	}
+
+	var functionsResult tuyaw.DeviceFunctionsResult
+	if err := json.Unmarshal(result, &functionsResult); err != nil {
+		return nil, fmt.Errorf("apiv1w: decoding category functions: %w", err)
+	}
+	return &functionsResult, nil
+}

--- a/v2/tuyaw/apiv1w/apiv1_test.go
+++ b/v2/tuyaw/apiv1w/apiv1_test.go
@@ -1,0 +1,666 @@
+package apiv1w
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AndreeJait/go-utility/v2/tuyaw"
+)
+
+// --- Interface compliance ---
+
+func TestInterfaceCompliance(t *testing.T) {
+	var _ tuyaw.Tuya = (*tuyaClient)(nil)
+}
+
+// --- Constructor tests ---
+
+func TestNew_NilConfig(t *testing.T) {
+	_, err := New(nil)
+	if err == nil {
+		t.Fatal("expected error for nil config")
+	}
+	if !strings.Contains(err.Error(), "config is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNew_EmptyAccessID(t *testing.T) {
+	_, err := New(&Config{AccessID: "", AccessKey: "secret"})
+	if err == nil {
+		t.Fatal("expected error for empty access id")
+	}
+	if !strings.Contains(err.Error(), "access id is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNew_EmptyAccessKey(t *testing.T) {
+	_, err := New(&Config{AccessID: "client123", AccessKey: ""})
+	if err == nil {
+		t.Fatal("expected error for empty access key")
+	}
+	if !strings.Contains(err.Error(), "access key is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNew_ValidConfig(t *testing.T) {
+	cf, err := New(&Config{AccessID: "client123", AccessKey: "secret"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cf == nil {
+		t.Fatal("expected non-nil client")
+	}
+}
+
+func TestNew_DefaultBaseURL(t *testing.T) {
+	client, err := New(&Config{AccessID: "client123", AccessKey: "secret"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := client.(*tuyaClient)
+	if c.baseURL != defaultBaseURL {
+		t.Fatalf("expected default base URL %q, got %q", defaultBaseURL, c.baseURL)
+	}
+	if c.baseURL != "https://openapi-sg.iotbing.com" {
+		t.Fatalf("expected Singapore base URL, got %q", c.baseURL)
+	}
+}
+
+func TestNew_CustomBaseURL(t *testing.T) {
+	client, err := New(&Config{AccessID: "client123", AccessKey: "secret", BaseURL: "https://custom.api.url"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := client.(*tuyaClient)
+	if c.baseURL != "https://custom.api.url" {
+		t.Fatalf("expected custom base URL, got %q", c.baseURL)
+	}
+}
+
+func TestNew_RegionOverride(t *testing.T) {
+	tests := []struct {
+		region   string
+		expected string
+	}{
+		{"us", RegionUS},
+		{"cn", RegionCN},
+		{"eu", RegionEU},
+		{"in", RegionIN},
+		{"sg", RegionSG},
+		{"US", RegionUS},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.region, func(t *testing.T) {
+			client, err := New(&Config{AccessID: "client123", AccessKey: "secret", Region: tt.region})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			c := client.(*tuyaClient)
+			if c.baseURL != tt.expected {
+				t.Fatalf("expected %s, got %s", tt.expected, c.baseURL)
+			}
+		})
+	}
+}
+
+func TestNew_InvalidRegion(t *testing.T) {
+	_, err := New(&Config{AccessID: "client123", AccessKey: "secret", Region: "xx"})
+	if err == nil {
+		t.Fatal("expected error for invalid region")
+	}
+}
+
+func TestNew_CustomHTTPClient(t *testing.T) {
+	customClient := &http.Client{}
+	cf, err := New(&Config{AccessID: "client123", AccessKey: "secret", HTTPClient: customClient})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := cf.(*tuyaClient)
+	if c.client != customClient {
+		t.Fatal("expected custom HTTP client to be used")
+	}
+}
+
+// --- Signing tests ---
+
+func TestSHA256Hex_EmptyBody(t *testing.T) {
+	result := sha256Hex("")
+	expected := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	if result != expected {
+		t.Fatalf("expected %s, got %s", expected, result)
+	}
+}
+
+func TestSHA256Hex_NonEmptyBody(t *testing.T) {
+	result := sha256Hex("hello")
+	if len(result) != 64 {
+		t.Fatalf("expected 64-char hex string, got %d chars", len(result))
+	}
+}
+
+func TestSign_TokenRequest(t *testing.T) {
+	client := &tuyaClient{
+		accessID:  "1KAD46OrT9HafiKdsXeg",
+		accessKey: "4OHBOnWOqaEC1mWXOpVL3yV50s0qGSRC",
+	}
+
+	// Token request: sign does NOT include access_token
+	sign := client.sign("GET", "/v1.0/token?grant_type=1", "", 1588925778000, "5138cc3a9033d69856923fd07b491173", "")
+	// Verify sign is uppercase hex
+	if sign != strings.ToUpper(sign) {
+		t.Fatalf("sign should be uppercase, got %s", sign)
+	}
+	if len(sign) != 64 {
+		t.Fatalf("sign should be 64 chars (SHA256 hex), got %d", len(sign))
+	}
+}
+
+func TestSign_BusinessRequest(t *testing.T) {
+	client := &tuyaClient{
+		accessID:  "1KAD46OrT9HafiKdsXeg",
+		accessKey: "4OHBOnWOqaEC1mWXOpVL3yV50s0qGSRC",
+	}
+
+	// Business request: sign INCLUDES access_token
+	sign := client.sign("GET", "/v1.0/devices/test-device-id/status", "", 1588925778000, "5138cc3a9033d69856923fd07b491173", "3f4eda2bdec17232f67c0b188af3eec1")
+	if sign != strings.ToUpper(sign) {
+		t.Fatalf("sign should be uppercase, got %s", sign)
+	}
+	if len(sign) != 64 {
+		t.Fatalf("sign should be 64 chars (SHA256 hex), got %d", len(sign))
+	}
+}
+
+// --- Helper to create test server and client ---
+
+func newTestClient(handler http.HandlerFunc) (tuyaw.Tuya, *httptest.Server) {
+	ts := httptest.NewServer(handler)
+	cf, _ := New(&Config{
+		AccessID:  "test-access-id",
+		AccessKey: "test-access-key",
+		BaseURL:   ts.URL,
+	})
+	return cf, ts
+}
+
+func writeTuyaJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	w.Write(data)
+}
+
+func tuyaSuccess(result any) map[string]any {
+	return map[string]any{
+		"success": true,
+		"result":  result,
+	}
+}
+
+func tuyaError(code int, msg string) map[string]any {
+	return map[string]any{
+		"success": false,
+		"code":    code,
+		"msg":     msg,
+	}
+}
+
+// --- Token tests ---
+
+func TestGetToken_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1.0/token" {
+			t.Fatalf("expected /v1.0/token, got %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("grant_type") != "1" {
+			t.Fatalf("expected grant_type=1, got %s", r.URL.Query().Get("grant_type"))
+		}
+		writeTuyaJSON(t, w, tuyaSuccess(map[string]any{
+			"access_token":  "test-access-token",
+			"refresh_token": "test-refresh-token",
+			"expire_time":   7200,
+			"uid":           "test-uid",
+		}))
+	})
+	defer ts.Close()
+
+	token, err := cf.GetToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.AccessToken != "test-access-token" {
+		t.Fatalf("expected test-access-token, got %s", token.AccessToken)
+	}
+	if token.RefreshToken != "test-refresh-token" {
+		t.Fatalf("expected test-refresh-token, got %s", token.RefreshToken)
+	}
+	if token.ExpireTime != 7200 {
+		t.Fatalf("expected 7200, got %d", token.ExpireTime)
+	}
+}
+
+func TestRefreshToken_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		writeTuyaJSON(t, w, tuyaSuccess(map[string]any{
+			"access_token":  "new-access-token",
+			"refresh_token": "new-refresh-token",
+			"expire_time":   7200,
+			"uid":           "test-uid",
+		}))
+	})
+	defer ts.Close()
+
+	token, err := cf.RefreshToken(context.Background(), "old-refresh-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.AccessToken != "new-access-token" {
+		t.Fatalf("expected new-access-token, got %s", token.AccessToken)
+	}
+}
+
+func TestGetToken_APIError(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		writeTuyaJSON(t, w, tuyaError(1001, "token expired"))
+	})
+	defer ts.Close()
+
+	_, err := cf.GetToken(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "1001") || !strings.Contains(err.Error(), "token expired") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// --- Device Management tests ---
+
+func TestGetDevice_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1.0/devices/device-123" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		writeTuyaJSON(t, w, tuyaSuccess(map[string]any{
+			"id":     "device-123",
+			"name":   "Living Room Light",
+			"category": "dj",
+			"online": true,
+		}))
+	})
+	defer ts.Close()
+
+	// Set a token so ensureToken doesn't try to get one
+	c := cf.(*tuyaClient)
+	c.setToken(&tuyaw.Token{AccessToken: "test-token", RefreshToken: "test-refresh", ExpireTime: 7200})
+
+	device, err := cf.GetDevice(context.Background(), "device-123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if device.ID != "device-123" {
+		t.Fatalf("expected device-123, got %s", device.ID)
+	}
+	if device.Name != "Living Room Light" {
+		t.Fatalf("expected Living Room Light, got %s", device.Name)
+	}
+}
+
+func TestListDevices_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		writeTuyaJSON(t, w, tuyaSuccess([]map[string]any{
+			{"id": "device-1", "name": "Light 1", "category": "dj", "online": true},
+			{"id": "device-2", "name": "Light 2", "category": "dj", "online": false},
+		}))
+	})
+	defer ts.Close()
+
+	c := cf.(*tuyaClient)
+	c.setToken(&tuyaw.Token{AccessToken: "test-token", RefreshToken: "test-refresh", ExpireTime: 7200})
+
+	devices, err := cf.ListDevices(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(devices) != 2 {
+		t.Fatalf("expected 2 devices, got %d", len(devices))
+	}
+}
+
+func TestListDevices_WithUID(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/v1.0/users/uid-123/devices") {
+			t.Fatalf("expected /v1.0/users/uid-123/devices, got %s", r.URL.Path)
+		}
+		writeTuyaJSON(t, w, tuyaSuccess([]map[string]any{
+			{"id": "device-1", "name": "Light 1", "category": "dj"},
+		}))
+	})
+	defer ts.Close()
+
+	c := cf.(*tuyaClient)
+	c.setToken(&tuyaw.Token{AccessToken: "test-token", RefreshToken: "test-refresh", ExpireTime: 7200})
+
+	devices, err := cf.ListDevices(context.Background(), &tuyaw.ListDevicesOptions{UID: "uid-123"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(devices))
+	}
+}
+
+func TestUpdateDeviceName_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("expected PUT, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1.0/devices/device-123" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		writeTuyaJSON(t, w, tuyaSuccess(true))
+	})
+	defer ts.Close()
+
+	c := cf.(*tuyaClient)
+	c.setToken(&tuyaw.Token{AccessToken: "test-token", RefreshToken: "test-refresh", ExpireTime: 7200})
+
+	err := cf.UpdateDeviceName(context.Background(), "device-123", "New Name")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteDevice_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", r.Method)
+		}
+		writeTuyaJSON(t, w, tuyaSuccess(true))
+	})
+	defer ts.Close()
+
+	c := cf.(*tuyaClient)
+	c.setToken(&tuyaw.Token{AccessToken: "test-token", RefreshToken: "test-refresh", ExpireTime: 7200})
+
+	err := cf.DeleteDevice(context.Background(), "device-123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetDeviceSpecifications_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		writeTuyaJSON(t, w, tuyaSuccess(map[string]any{
+			"functions": []map[string]any{
+				{"code": "switch_led", "type": "Boolean", "values": "{}", "name": "Switch"},
+			},
+			"status": []map[string]any{
+				{"code": "switch_led", "type": "Boolean", "value": false, "name": "Switch"},
+			},
+		}))
+	})
+	defer ts.Close()
+
+	c := cf.(*tuyaClient)
+	c.setToken(&tuyaw.Token{AccessToken: "test-token", RefreshToken: "test-refresh", ExpireTime: 7200})
+
+	spec, err := cf.GetDeviceSpecifications(context.Background(), "device-123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(spec.Functions) != 1 {
+		t.Fatalf("expected 1 function, got %d", len(spec.Functions))
+	}
+	if spec.Functions[0].Code != "switch_led" {
+		t.Fatalf("expected switch_led, got %s", spec.Functions[0].Code)
+	}
+}
+
+// --- Device Control tests ---
+
+func TestSendCommands_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1.0/devices/device-123/commands" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		json.Unmarshal(body, &req)
+		commands, ok := req["commands"].([]any)
+		if !ok || len(commands) != 1 {
+			t.Fatalf("expected 1 command, got %v", req["commands"])
+		}
+		writeTuyaJSON(t, w, tuyaSuccess(true))
+	})
+	defer ts.Close()
+
+	c := cf.(*tuyaClient)
+	c.setToken(&tuyaw.Token{AccessToken: "test-token", RefreshToken: "test-refresh", ExpireTime: 7200})
+
+	err := cf.SendCommands(context.Background(), "device-123", []tuyaw.DeviceCommand{
+		{Code: "switch_led", Value: true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetDeviceStatus_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		writeTuyaJSON(t, w, tuyaSuccess([]map[string]any{
+			{"code": "switch_led", "type": "Boolean", "value": true},
+			{"code": "bright", "type": "Integer", "value": 30},
+		}))
+	})
+	defer ts.Close()
+
+	c := cf.(*tuyaClient)
+	c.setToken(&tuyaw.Token{AccessToken: "test-token", RefreshToken: "test-refresh", ExpireTime: 7200})
+
+	status, err := cf.GetDeviceStatus(context.Background(), "device-123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(status) != 2 {
+		t.Fatalf("expected 2 status points, got %d", len(status))
+	}
+	if status[0].Code != "switch_led" {
+		t.Fatalf("expected switch_led, got %s", status[0].Code)
+	}
+}
+
+func TestGetDeviceFunctions_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		writeTuyaJSON(t, w, tuyaSuccess(map[string]any{
+			"category": "dj",
+			"functions": []map[string]any{
+				{"code": "switch_led", "type": "Boolean", "values": "{}", "name": "Switch"},
+				{"code": "bright", "type": "Integer", "values": "{\"min\":10,\"max\":1000,\"scale\":0,\"step\":1}", "name": "Brightness"},
+			},
+		}))
+	})
+	defer ts.Close()
+
+	c := cf.(*tuyaClient)
+	c.setToken(&tuyaw.Token{AccessToken: "test-token", RefreshToken: "test-refresh", ExpireTime: 7200})
+
+	result, err := cf.GetDeviceFunctions(context.Background(), "device-123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Category != "dj" {
+		t.Fatalf("expected category dj, got %s", result.Category)
+	}
+	if len(result.Functions) != 2 {
+		t.Fatalf("expected 2 functions, got %d", len(result.Functions))
+	}
+	if result.Functions[0].Code != "switch_led" {
+		t.Fatalf("expected switch_led, got %s", result.Functions[0].Code)
+	}
+}
+
+func TestGetCategoryFunctions_Success(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1.0/functions/dj" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		writeTuyaJSON(t, w, tuyaSuccess(map[string]any{
+			"category": "dj",
+			"functions": []map[string]any{
+				{"code": "switch_led", "type": "Boolean", "values": "{}", "name": "Switch"},
+			},
+		}))
+	})
+	defer ts.Close()
+
+	c := cf.(*tuyaClient)
+	c.setToken(&tuyaw.Token{AccessToken: "test-token", RefreshToken: "test-refresh", ExpireTime: 7200})
+
+	result, err := cf.GetCategoryFunctions(context.Background(), "dj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Functions) != 1 {
+		t.Fatalf("expected 1 function, got %d", len(result.Functions))
+	}
+}
+
+// --- Error path tests ---
+
+func TestDoRequest_APIError(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		writeTuyaJSON(t, w, tuyaError(1106, "invalid permission"))
+	})
+	defer ts.Close()
+
+	c := cf.(*tuyaClient)
+	c.setToken(&tuyaw.Token{AccessToken: "test-token", RefreshToken: "test-refresh", ExpireTime: 7200})
+
+	_, err := cf.GetDevice(context.Background(), "device-123")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "1106") || !strings.Contains(err.Error(), "invalid permission") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDoRequest_InvalidJSON(t *testing.T) {
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	})
+	defer ts.Close()
+
+	c := cf.(*tuyaClient)
+	c.setToken(&tuyaw.Token{AccessToken: "test-token", RefreshToken: "test-refresh", ExpireTime: 7200})
+
+	_, err := cf.GetDevice(context.Background(), "device-123")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "decoding response") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// --- Token auto-refresh test ---
+
+func TestTokenAutoRefresh(t *testing.T) {
+	tokenCount := 0
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/v1.0/token") {
+			tokenCount++
+			writeTuyaJSON(t, w, tuyaSuccess(map[string]any{
+				"access_token":  "token-" + strconv.Itoa(tokenCount),
+				"refresh_token": "refresh-" + strconv.Itoa(tokenCount),
+				"expire_time":   7200,
+				"uid":           "test-uid",
+			}))
+			return
+		}
+		// Business request
+		writeTuyaJSON(t, w, tuyaSuccess(map[string]any{
+			"id":     "device-1",
+			"name":   "Test",
+			"online": true,
+		}))
+	})
+	defer ts.Close()
+
+	// Set an expired token to trigger refresh
+	c := cf.(*tuyaClient)
+	c.setToken(&tuyaw.Token{
+		AccessToken:  "expired-token",
+		RefreshToken: "expired-refresh",
+		ExpireTime:   1, // 1 second
+	})
+	// Manually expire it
+	c.mu.Lock()
+	c.expireAt = time.Now().Add(-1 * time.Hour)
+	c.mu.Unlock()
+
+	// This should trigger a token refresh
+	_, err := cf.GetDevice(context.Background(), "device-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if tokenCount == 0 {
+		t.Fatal("expected token request to be made")
+	}
+}
+
+// --- Signing headers test ---
+
+func TestRequestHeaders_SentOnEveryRequest(t *testing.T) {
+	var capturedHeaders = make(map[string]string)
+	cf, ts := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders["client_id"] = r.Header.Get("client_id")
+		capturedHeaders["sign"] = r.Header.Get("sign")
+		capturedHeaders["sign_method"] = r.Header.Get("sign_method")
+		capturedHeaders["t"] = r.Header.Get("t")
+		capturedHeaders["nonce"] = r.Header.Get("nonce")
+		writeTuyaJSON(t, w, tuyaSuccess([]any{}))
+	})
+	defer ts.Close()
+
+	c := cf.(*tuyaClient)
+	c.setToken(&tuyaw.Token{AccessToken: "test-token", RefreshToken: "test-refresh", ExpireTime: 7200})
+
+	_, _ = cf.ListDevices(context.Background(), nil)
+
+	if capturedHeaders["client_id"] != "test-access-id" {
+		t.Fatalf("expected client_id 'test-access-id', got %q", capturedHeaders["client_id"])
+	}
+	if capturedHeaders["sign_method"] != "HMAC-SHA256" {
+		t.Fatalf("expected sign_method HMAC-SHA256, got %q", capturedHeaders["sign_method"])
+	}
+	if capturedHeaders["sign"] == "" {
+		t.Fatal("expected non-empty sign header")
+	}
+	if capturedHeaders["t"] == "" {
+		t.Fatal("expected non-empty t header")
+	}
+	if capturedHeaders["nonce"] == "" {
+		t.Fatal("expected non-empty nonce header")
+	}
+}

--- a/v2/tuyaw/apiv1w/integration_test.go
+++ b/v2/tuyaw/apiv1w/integration_test.go
@@ -1,0 +1,240 @@
+//go:build integration
+
+package apiv1w
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/AndreeJait/go-utility/v2/logw"
+	"github.com/AndreeJait/go-utility/v2/tuyaw"
+)
+
+// newIntegrationClient creates a Tuya client for integration testing.
+// Requires TUYA_ACCESS_ID and TUYA_ACCESS_KEY environment variables.
+//
+// Run with:
+//
+//	cd v2 && go test ./tuyaw/apiv1w/ -tags=integration -run TestIntegration -v -timeout 120s
+func newIntegrationClient(t *testing.T) tuyaw.Tuya {
+	t.Helper()
+
+	accessID := os.Getenv("TUYA_ACCESS_ID")
+	if accessID == "" {
+		t.Fatal("TUYA_ACCESS_ID environment variable is required for integration tests")
+	}
+
+	accessKey := os.Getenv("TUYA_ACCESS_KEY")
+	if accessKey == "" {
+		t.Fatal("TUYA_ACCESS_KEY environment variable is required for integration tests")
+	}
+
+	cf, err := New(&Config{
+		AccessID:  accessID,
+		AccessKey: accessKey,
+		DebugMode: true,
+		Region:    "Sg",
+	})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	return cf
+}
+
+func getEnvOrDefault(key, defaultVal string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultVal
+}
+
+func TestIntegration_GetToken(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cf := newIntegrationClient(t)
+	token, err := cf.GetToken(ctx)
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	t.Logf("token: access_token=%s... refresh_token=%s... expire_time=%d uid=%s",
+		token.AccessToken[:min(10, len(token.AccessToken))],
+		token.RefreshToken[:min(10, len(token.RefreshToken))],
+		token.ExpireTime,
+		token.UID,
+	)
+
+	if token.AccessToken == "" {
+		t.Fatal("expected non-empty access token")
+	}
+	if token.RefreshToken == "" {
+		t.Fatal("expected non-empty refresh token")
+	}
+}
+
+func TestIntegration_RefreshToken(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cf := newIntegrationClient(t)
+
+	// First get a token
+	token, err := cf.GetToken(ctx)
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+
+	// Then refresh it
+	newToken, err := cf.RefreshToken(ctx, token.RefreshToken)
+	if err != nil {
+		t.Fatalf("RefreshToken: %v", err)
+	}
+	t.Logf("refreshed token: access_token=%s... expire_time=%d",
+		newToken.AccessToken[:min(10, len(newToken.AccessToken))],
+		newToken.ExpireTime,
+	)
+
+	if newToken.AccessToken == "" {
+		t.Fatal("expected non-empty access token after refresh")
+	}
+}
+
+func TestIntegration_ListDevices(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cf := newIntegrationClient(t)
+
+	// Get token first
+	_, err := cf.GetToken(ctx)
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+
+	uid := os.Getenv("TUYA_UID")
+	if uid == "" {
+		t.Skip("TUYA_UID environment variable not set, skipping list devices test")
+	}
+
+	devices, err := cf.ListDevices(ctx, &tuyaw.ListDevicesOptions{UID: uid})
+	if err != nil {
+		t.Fatalf("ListDevices: %v", err)
+	}
+	t.Logf("devices count: %d", len(devices))
+
+	for i, d := range devices {
+		t.Logf("device[%d]: id=%s name=%s category=%s online=%v", i, d.ID, d.Name, d.Category, d.Online)
+	}
+}
+
+func TestIntegration_GetDevice_Status(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cf := newIntegrationClient(t)
+
+	// Get token first
+	_, err := cf.GetToken(ctx)
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+
+	deviceID := os.Getenv("TUYA_DEVICE_ID")
+	if deviceID == "" {
+		t.Skip("TUYA_DEVICE_ID environment variable not set, skipping device test")
+	}
+
+	// Get device details
+	device, err := cf.GetDevice(ctx, deviceID)
+	if err != nil {
+		t.Fatalf("GetDevice: %v", err)
+	}
+	t.Logf("device: id=%s name=%s category=%s online=%v", device.ID, device.Name, device.Category, device.Online)
+
+	// Get device status
+	status, err := cf.GetDeviceStatus(ctx, deviceID)
+	if err != nil {
+		t.Fatalf("GetDeviceStatus: %v", err)
+	}
+	t.Logf("device status: %d points", len(status))
+	for i, s := range status {
+		t.Logf("  status[%d]: code=%s type=%s value=%v", i, s.Code, s.Type, s.Value)
+	}
+}
+
+func TestIntegration_GetDeviceFunctions(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cf := newIntegrationClient(t)
+
+	// Get token first
+	_, err := cf.GetToken(ctx)
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+
+	deviceID := os.Getenv("TUYA_DEVICE_ID")
+	if deviceID == "" {
+		t.Skip("TUYA_DEVICE_ID environment variable not set, skipping functions test")
+	}
+
+	functions, err := cf.GetDeviceFunctions(ctx, deviceID)
+	if err != nil {
+		t.Fatalf("GetDeviceFunctions: %v", err)
+	}
+	t.Logf("device category: %s, functions: %d", functions.Category, len(functions.Functions))
+	for i, f := range functions.Functions {
+		t.Logf("  function[%d]: code=%s type=%s name=%s", i, f.Code, f.Type, f.Name)
+	}
+}
+
+func TestIntegration_SendCommands(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cf := newIntegrationClient(t)
+
+	// Get token first
+	_, err := cf.GetToken(ctx)
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+
+	deviceID := os.Getenv("TUYA_DEVICE_ID")
+	if deviceID == "" {
+		t.Skip("TUYA_DEVICE_ID environment variable not set, skipping commands test")
+	}
+
+	// Get current status to find a safe command to send
+	functions, err := cf.GetDeviceFunctions(ctx, deviceID)
+	if err != nil {
+		t.Fatalf("GetDeviceStatus: %v", err)
+	}
+
+	logw.CtxInfof(ctx, "%v", functions)
+	err = cf.SendCommands(ctx, deviceID, []tuyaw.DeviceCommand{
+		{
+			Code:  "switch",
+			Value: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("SendCommands: %v", err)
+	}
+
+	time.Sleep(5 * time.Second)
+
+	logw.CtxInfof(ctx, "%v", functions)
+	err = cf.SendCommands(ctx, deviceID, []tuyaw.DeviceCommand{
+		{
+			Code:  "switch",
+			Value: false,
+		},
+	})
+	if err != nil {
+		t.Fatalf("SendCommands: %v", err)
+	}
+}

--- a/v2/tuyaw/tuya.go
+++ b/v2/tuyaw/tuya.go
@@ -1,0 +1,162 @@
+package tuyaw
+
+import "context"
+
+// Token represents a Tuya access token and its associated metadata.
+type Token struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpireTime   int    `json:"expire_time"` // seconds
+	UID          string `json:"uid"`
+}
+
+// Device represents a Tuya smart home device.
+type Device struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Category     string `json:"category"`
+	ProductID    string `json:"product_id"`
+	ProductName  string `json:"product_name"`
+	ProductImg   string `json:"product_img"`
+	Model        string `json:"model"`
+	Sub          bool   `json:"sub"`
+	UUID         string `json:"uuid"`
+	Online       bool   `json:"online"`
+	Icon         string `json:"icon"`
+	TimeZoneID   string `json:"time_zone_id"`
+	LocalKey     string `json:"local_key"`
+	ActiveTime   int64  `json:"active_time"`
+	CreateTime   int64  `json:"create_time"`
+	UpdateStatus int    `json:"update_status"`
+	Status       []DeviceStatusPoint `json:"status,omitempty"`
+}
+
+// DeviceFunction represents a controllable function point of a device.
+type DeviceFunction struct {
+	Code   string `json:"code"`
+	Type   string `json:"type"`   // Boolean, Integer, Enum, Json
+	Values string `json:"values"` // value range description
+	Name   string `json:"name"`
+	Desc   string `json:"desc"`
+}
+
+// DeviceFunctionsResult wraps the functions response from the Tuya API.
+// The API returns {"category": "...", "functions": [...]} rather than a plain array.
+type DeviceFunctionsResult struct {
+	Category  string           `json:"category"`
+	Functions []DeviceFunction `json:"functions"`
+}
+
+// DeviceSpecification represents the specification of a device (functions + status set).
+type DeviceSpecification struct {
+	Functions []DeviceFunction    `json:"functions"`
+	Status   []DeviceStatusPoint  `json:"status"`
+}
+
+// DeviceStatusPoint represents a single status point of a device.
+type DeviceStatusPoint struct {
+	Code  string `json:"code"`
+	Type  string `json:"type"`
+	Value any    `json:"value"`
+	Name  string `json:"name"`
+}
+
+// DeviceCommand represents a command to send to a device.
+type DeviceCommand struct {
+	Code  string `json:"code"`
+	Value any    `json:"value"`
+}
+
+// DeviceLog represents a single device log entry.
+type DeviceLog struct {
+	Time     string `json:"time"`
+	Value    string `json:"value"`
+	Category string `json:"category"`
+}
+
+// DeviceFactoryInfo represents factory information for a device.
+type DeviceFactoryInfo struct {
+	ID  string `json:"id"`
+	MAC string `json:"mac,omitempty"`
+	UUID string `json:"uuid,omitempty"`
+	SN  string `json:"sn,omitempty"`
+}
+
+// SubDevice represents a sub-device under a gateway device.
+type SubDevice struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Online   bool   `json:"online"`
+	Category string `json:"category"`
+	Icon     string `json:"icon"`
+}
+
+// ListDevicesOptions provides optional parameters for listing devices.
+type ListDevicesOptions struct {
+	UID        string // filter by user ID (required for /v1.0/users/{uid}/devices)
+	ProductID  string // filter by product ID
+	DeviceIDs  []string // filter by device IDs
+	PageNo     int    // page number (1-based)
+	PageSize   int    // items per page
+}
+
+// DeviceLogOptions provides optional parameters for querying device logs.
+type DeviceLogOptions struct {
+	StartTime int64  // unix milliseconds
+	EndTime   int64  // unix milliseconds
+	Category  string // log category
+	PageNo    int
+	PageSize  int
+}
+
+// Tuya defines the contract for interacting with the Tuya IoT Cloud API v1.
+type Tuya interface {
+	// --- Token Management ---
+
+	// GetToken obtains a new access token using simple mode (grant_type=1).
+	GetToken(ctx context.Context) (*Token, error)
+
+	// RefreshToken refreshes an access token using a refresh token.
+	RefreshToken(ctx context.Context, refreshToken string) (*Token, error)
+
+	// --- Device Management ---
+
+	// GetDevice returns details for a single device.
+	GetDevice(ctx context.Context, deviceID string) (*Device, error)
+
+	// ListDevices returns devices based on the provided options.
+	// If opts.UID is set, uses /v1.0/users/{uid}/devices.
+	ListDevices(ctx context.Context, opts *ListDevicesOptions) ([]Device, error)
+
+	// UpdateDeviceName modifies the name of a device.
+	UpdateDeviceName(ctx context.Context, deviceID, name string) error
+
+	// DeleteDevice removes a device.
+	DeleteDevice(ctx context.Context, deviceID string) error
+
+	// GetDeviceSpecifications returns the specification (functions + status) of a device.
+	GetDeviceSpecifications(ctx context.Context, deviceID string) (*DeviceSpecification, error)
+
+	// GetDeviceFactoryInfos returns factory information for the specified devices.
+	GetDeviceFactoryInfos(ctx context.Context, deviceIDs []string) ([]DeviceFactoryInfo, error)
+
+	// ListSubDevices returns sub-devices under a gateway device.
+	ListSubDevices(ctx context.Context, deviceID string) ([]SubDevice, error)
+
+	// GetDeviceLogs returns logs for a device.
+	GetDeviceLogs(ctx context.Context, deviceID string, opts *DeviceLogOptions) ([]DeviceLog, error)
+
+	// --- Device Control ---
+
+	// SendCommands sends commands to a device.
+	SendCommands(ctx context.Context, deviceID string, commands []DeviceCommand) error
+
+	// GetDeviceStatus returns the current status of a device.
+	GetDeviceStatus(ctx context.Context, deviceID string) ([]DeviceStatusPoint, error)
+
+	// GetDeviceFunctions returns the instruction set supported by a device.
+	GetDeviceFunctions(ctx context.Context, deviceID string) (*DeviceFunctionsResult, error)
+
+	// GetCategoryFunctions returns the instruction set for a product category.
+	GetCategoryFunctions(ctx context.Context, category string) (*DeviceFunctionsResult, error)
+}


### PR DESCRIPTION
  - cloudflarw: Cloudflare API v4 wrapper with tunnel, DNS, zone, and access app management
  - tuyaw: Tuya IoT Cloud API v1 wrapper with HMAC-SHA256 auth, device management and control
  - llmw/openaiw: add HTTPClient config option for injecting authenticated clients
